### PR TITLE
Lots of fixes

### DIFF
--- a/includes/class-wc-pakettikauppa-admin.php
+++ b/includes/class-wc-pakettikauppa-admin.php
@@ -500,12 +500,10 @@ class WC_Pakettikauppa_Admin
         }
 
         if (false !== $shipment_id) {
-            $tracking_code = get_post_meta($post_id, '_wc_pakettikauppa_tracking_code', true);
-
-            $contents = $this->wc_pakettikauppa_shipment->fetchShippingLabel($tracking_code);
+            $contents = $this->wc_pakettikauppa_shipment->fetchShippingLabel($shipment_id);
             // Output
             header('Content-type:application/pdf');
-            header("Content-Disposition:inline;filename={$tracking_code}.pdf");
+            header("Content-Disposition:inline;filename={$shipment_id}.pdf");
             print $contents;
             exit;
         }

--- a/includes/class-wc-pakettikauppa-admin.php
+++ b/includes/class-wc-pakettikauppa-admin.php
@@ -475,16 +475,12 @@ class WC_Pakettikauppa_Admin {
     }
 
     if ( false !== $shipment_id ) {
-      $upload_dir = wp_upload_dir();
+        $tracking_code = get_post_meta($post_id, '_wc_pakettikauppa_tracking_code', true);
 
-      // Read file
-      $filepath = WC_PAKETTIKAUPPA_PRIVATE_DIR . '/' . $shipment_id . '.pdf';
-      header('X-Sendfile: ' . $filepath);
-
+        $contents = $this->wc_pakettikauppa_shipment->fetchShippingLabel($tracking_code);
       // Output
-      $contents = file_get_contents( $filepath );
       header('Content-type:application/pdf');
-      header("Content-Disposition:inline;filename={$shipment_id}.pdf");
+      header("Content-Disposition:inline;filename={$tracking_code}.pdf");
       print $contents;
       exit;
     }
@@ -529,16 +525,6 @@ class WC_Pakettikauppa_Admin {
     $post_type = get_post_type( $post_id );
     if ( $post_type !== 'shop_order' ) {
       return;
-    }
-
-    $tracking_code = get_post_meta( $post_id, '_wc_pakettikauppa_tracking_code', true );
-    if ( ! empty( $tracking_code ) ) {
-      $filepath = WC_PAKETTIKAUPPA_PRIVATE_DIR . '/' . $tracking_code . '.pdf';
-
-      // Delete if file exists
-      if ( file_exists( $filepath) ) {
-        unlink( $filepath );
-      }
     }
   }
 

--- a/includes/class-wc-pakettikauppa-admin.php
+++ b/includes/class-wc-pakettikauppa-admin.php
@@ -276,7 +276,7 @@ class WC_Pakettikauppa_Admin
                         <h4><?php esc_attr_e('Service', 'wc-pakettikauppa'); ?></h4>
                         <?php foreach ($active_shipping_options as $shipping_code => $shipping_settings) : ?>
                             <?php if ($shipping_settings['active'] === 'yes') : ?>
-                                <?php if ($service_id === $shipping_code) : ?>
+                                <?php if ($service_id == $shipping_code) : ?>
                                     <label for="service-<?php echo esc_attr($shipping_code); ?>">
                                     <input type="radio"
                                            name="wc_pakettikauppa_service_id"
@@ -437,11 +437,12 @@ class WC_Pakettikauppa_Admin
         }
 
         if (false !== $shipment_id) {
-            $contents = $this->wc_pakettikauppa_shipment->fetchShippingLabel($shipment_id);
+            $contents = $this->wc_pakettikauppa_shipment->fetch_shipping_label($shipment_id);
+
             // Output
             header('Content-type:application/pdf');
             header("Content-Disposition:inline;filename={$shipment_id}.pdf");
-            print $contents;
+            print base64_decode($contents->{"response.file"});
             exit;
         }
 

--- a/includes/class-wc-pakettikauppa-admin.php
+++ b/includes/class-wc-pakettikauppa-admin.php
@@ -1,8 +1,8 @@
 <?php
 
 // Prevent direct access to this script
-if ( ! defined( 'ABSPATH' ) ) {
-  exit;
+if (!defined('ABSPATH')) {
+    exit;
 }
 
 require_once WC_PAKETTIKAUPPA_DIR . 'includes/class-wc-pakettikauppa-shipping-method.php';
@@ -17,515 +17,542 @@ require_once WC_PAKETTIKAUPPA_DIR . 'includes/class-wc-pakettikauppa-shipment.ph
  * @package  woocommerce-pakettikauppa
  * @author Seravo
  */
-class WC_Pakettikauppa_Admin {
-  private $wc_pakettikauppa_shipment = null;
-  private $errors                    = array();
+class WC_Pakettikauppa_Admin
+{
+    private $wc_pakettikauppa_shipment = null;
+    private $errors = array();
 
-  public function __construct() {
-    $this->id = 'wc_pakettikauppa_admin';
-  }
-
-  public function load() {
-    add_filter( 'plugin_action_links_' . WC_PAKETTIKAUPPA_BASENAME, array( $this, 'add_settings_link' ) );
-    add_filter( 'plugin_row_meta', array( $this, 'plugin_row_meta' ), 10, 2 );
-
-    add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
-    add_action( 'add_meta_boxes', array( $this, 'register_meta_boxes' ) );
-    add_action( 'save_post', array( $this, 'save_metabox' ), 10, 2 );
-    add_action( 'admin_post_show_pakettikauppa', array( $this, 'show' ), 10 );
-    add_action( 'woocommerce_email_order_meta', array( $this, 'attach_tracking_to_email' ), 10, 4 );
-    add_action( 'woocommerce_admin_order_data_after_shipping_address', array( $this, 'show_pickup_point_in_admin_order_meta' ), 10, 1 );
-    // Delete the tracking label when order is deleted so the uploads directory doesn't get too bloated
-    add_action( 'before_delete_post', array( $this, 'delete_order_shipping_label' ) );
-    // Connect shipping service and pickup points in admin
-    add_action( 'wp_ajax_admin_update_pickup_point', array( $this, 'update_meta_box_pickup_points' ) );
-
-    try {
-      $this->wc_pakettikauppa_shipment = new WC_Pakettikauppa_Shipment();
-      $this->wc_pakettikauppa_shipment->load();
-
-    } catch ( Exception $e ) {
-      $this->add_error( $e->getMessage() );
-      $this->add_error_notice( $e->getMessage() );
-      return;
-    }
-  }
-
-  /**
-   * Check if the selected service has pickup points via wp_ajax
-   */
-  public function update_meta_box_pickup_points() {
-    if ( isset( $_POST ) && ! empty( $_POST['service_id'] ) ) {
-      $service_id = $_POST['service_id'];
-      echo esc_attr( WC_Pakettikauppa_Shipment::service_has_pickup_points( $service_id ) );
-      wp_die();
-    }
-  }
-
-  /**
-   * Add an error with a specified error message.
-   *
-   * @param string $message A message containing details about the error.
-   */
-  public function add_error( $message ) {
-    if ( ! empty( $message ) ) {
-      array_push( $this->errors, $message );
-      error_log( $message );
-    }
-  }
-
-  /**
-   * Return all errors that have been added via add_error().
-   *
-   * @return array Errors
-   */
-  public function get_errors() {
-    return $this->errors;
-  }
-
-  /**
-   * Clear all existing errors that have been added via add_error().
-   */
-  public function clear_errors() {
-    unset( $this->errors );
-    $this->errors = array();
-  }
-
-  /**
-   * Add an admin error notice to wp-admin.
-   */
-  public function add_error_notice( $message ) {
-    if ( ! empty( $message ) ) {
-      $class = 'notice notice-error';
-      /* translators: %s: Error message */
-      $print_error = wp_sprintf( __( 'An error occured: %s', 'wc-pakettikauppa' ), $message );
-      printf( '<div class="%1$s"><p>%2$s</p></div>', esc_attr( $class ), esc_html( $print_error ) );
-    }
-  }
-
-  /**
-   * Show row meta on the plugin screen.
-   *
-   * @param  mixed $links Plugin Row Meta
-   * @param  mixed $file  Plugin Base file
-   * @return  array
-   */
-  public static function plugin_row_meta( $links, $file ) {
-    if ( WC_PAKETTIKAUPPA_BASENAME === $file ) {
-      $row_meta = array(
-        'service' => '<a href="' . esc_url( 'https://www.pakettikauppa.fi' ) .
-          '" aria-label="' . esc_attr__( 'Visit Pakettikauppa', 'wc-pakettikauppa' ) .
-          '">' . esc_html__( 'Show site Pakettikauppa', 'wc-pakettikauppa' ) . '</a>',
-      );
-      return array_merge( $links, $row_meta );
-    }
-    return (array) $links;
-  }
-
-  /**
-   * Register meta boxes for WooCommerce order metapage.
-   */
-  public function register_meta_boxes() {
-    foreach ( wc_get_order_types( 'order-meta-boxes' ) as $type ) {
-      $order_type_object = get_post_type_object( $type );
-      add_meta_box(
-        'wc-pakettikauppa',
-        esc_attr__( 'Pakettikauppa', 'wc-pakettikauppa' ),
-        array(
-          $this,
-          'meta_box',
-        ),
-        $type,
-        'side',
-        'default'
-      );
-    }
-  }
-
-  /**
-   * Enqueue admin-specific styles and scripts.
-   */
-  public function admin_enqueue_scripts() {
-    wp_enqueue_style( 'wc_pakettikauppa_admin', plugin_dir_url( __FILE__ ) . '../assets/css/wc-pakettikauppa-admin.css' );
-    wp_enqueue_script( 'wc_pakettikauppa_admin_js', plugin_dir_url( __FILE__ ) . '../assets/js/wc-pakettikauppa-admin.js', array( 'jquery' ) );
-  }
-
-  /**
-   * Add settings link to the Pakettikauppa metabox on the plugins page when used with
-   * the WordPress hook plugin_action_links_woocommerce-pakettikauppa.
-   *
-   * @param array $links Already existing links on the plugin metabox
-   * @return array The plugin settings page link appended to the already existing links
-   */
-  public function add_settings_link( $links ) {
-    $url  = admin_url( 'admin.php?page=wc-settings&tab=shipping&section=wc_pakettikauppa_shipping_method' );
-    $link = '<a href="' . $url . '">' . esc_attr__( 'Settings' ) . '</a>';
-
-    return array_merge( array( $link ), $links );
-  }
-
-  /**
-   * Show the selected pickup point in admin order meta. Use together with the hook
-   * woocommerce_admin_order_data_after_shipping_address.
-   *
-   * @param WC_Order $order The order that is currently being viewed in wp-admin
-   */
-  public function show_pickup_point_in_admin_order_meta( $order ) {
-    echo '<p class="form-field"><strong>' . esc_attr__('Requested pickup point', 'wc-pakettikauppa') . ':</strong><br>';
-    if ( $order->get_meta('_pakettikauppa_pickup_point') ) {
-      echo esc_attr( $order->get_meta('_pakettikauppa_pickup_point') );
-      echo '<br>ID: ' . esc_attr( $order->get_meta('_pakettikauppa_pickup_point_id') );
-    } else {
-      echo esc_attr__('None');
-    }
-    echo '</p>';
-  }
-
-  /**
-   * Meta box for managing shipments.
-   */
-  public function meta_box( $post ) {
-    $order = wc_get_order( $post->ID );
-
-    if ( ! WC_Pakettikauppa_Shipment::validate_order_shipping_receiver( $order ) ) {
-      esc_attr_e( 'Please add shipping info to the order to manage Pakettikauppa shipments.', 'wc-pakettikauppa' );
-      return;
+    public function __construct()
+    {
+        $this->id = 'wc_pakettikauppa_admin';
     }
 
-    // Get active services from active_shipping_options
-    $settings                = get_option( 'woocommerce_WC_Pakettikauppa_Shipping_Method_settings', null );
-    $active_shipping_options = json_decode( $settings['active_shipping_options'], true );
+    public function load()
+    {
+        add_filter('plugin_action_links_' . WC_PAKETTIKAUPPA_BASENAME, array($this, 'add_settings_link'));
+        add_filter('plugin_row_meta', array($this, 'plugin_row_meta'), 10, 2);
 
-    // The tracking code will only be available if the shipment label has been generated
-    $tracking_code = get_post_meta( $post->ID, '_wc_pakettikauppa_tracking_code', true);
-    $cod           = get_post_meta( $post->ID, '_wc_pakettikauppa_cod', true);
-    $cod_amount    = get_post_meta( $post->ID, '_wc_pakettikauppa_cod_amount', true);
-    $cod_reference = get_post_meta( $post->ID, '_wc_pakettikauppa_cod_reference', true);
-    $service_id    = get_post_meta( $post->ID, '_wc_pakettikauppa_service_id', true);
+        add_action('admin_enqueue_scripts', array($this, 'admin_enqueue_scripts'));
+        add_action('add_meta_boxes', array($this, 'register_meta_boxes'));
+        add_action('save_post', array($this, 'save_metabox'), 10, 2);
+        add_action('admin_post_show_pakettikauppa', array($this, 'show'), 10);
+        add_action('woocommerce_email_order_meta', array($this, 'attach_tracking_to_email'), 10, 4);
+        add_action('woocommerce_admin_order_data_after_shipping_address', array($this, 'show_pickup_point_in_admin_order_meta'), 10, 1);
+        // Delete the tracking label when order is deleted so the uploads directory doesn't get too bloated
+        add_action('before_delete_post', array($this, 'delete_order_shipping_label'));
+        // Connect shipping service and pickup points in admin
+        add_action('wp_ajax_admin_update_pickup_point', array($this, 'update_meta_box_pickup_points'));
 
-    $shipping_methods = $order->get_shipping_methods();
-    $shipping_method  = reset( $shipping_methods );
-    $ids              = explode( ':', $shipping_method['method_id'] );
-    if ( isset( $ids[1] ) && ! empty( $ids[1] ) ) {
-      $service_id = (int) $ids[1];
-    }
+        try {
+            $this->wc_pakettikauppa_shipment = new WC_Pakettikauppa_Shipment();
+            $this->wc_pakettikauppa_shipment->load();
 
-    $pickup_point    = $order->get_meta('_pakettikauppa_pickup_point');
-    $pickup_point_id = $order->get_meta('_pakettikauppa_pickup_point_id');
-    $status          = get_post_meta( $post->ID, '_wc_pakettikauppa_shipment_status', true);
-
-    // Set defaults
-    if ( empty( $cod ) ) {
-      $cod = ( $order->get_payment_method() === 'cod' );
-    }
-    if ( empty( $cod_amount) ) {
-      $cod_amount = $order->get_total();
-    }
-    if ( empty( $cod_reference) ) {
-      $cod_reference = WC_Pakettikauppa_Shipment::calculate_reference( $post->ID );
-    }
-    if ( empty( $service_id ) ) {
-      $service_id = WC_Pakettikauppa_Shipment::get_default_service($post, $order);
-    }
-
-    $document_url = admin_url( 'admin-post.php?post=' . $post->ID . '&action=show_pakettikauppa&sid=' . $tracking_code );
-    $tracking_url = WC_Pakettikauppa_Shipment::tracking_url( $service_id, $tracking_code );
-
-    ?>
-    <div>
-      <?php if ( ! empty( $tracking_code ) ) : ?>
-        <p class="pakettikauppa-shipment">
-          <strong>
-            <?php
-            printf(
-              '%1$s<br>%2$s<br>%3$s',
-              esc_attr( $this->wc_pakettikauppa_shipment->service_title($service_id) ),
-              esc_attr( $tracking_code ),
-              esc_attr( WC_Pakettikauppa_Shipment::get_status_text($status) )
-            );
-            ?>
-          </strong><br>
-
-          <a href="<?php echo esc_url( $document_url ); ?>" target="_blank" class="download"><?php esc_attr_e( 'Print document', 'wc-pakettikauppa' ); ?></a>&nbsp;-&nbsp;
-
-          <?php if ( ! empty( $tracking_url ) ) : ?>
-            <a href="<?php echo esc_url( $tracking_url ); ?>" target="_blank" class="tracking"><?php esc_attr_e( 'Track', 'wc-pakettikauppa' ); ?></a>
-          <?php endif; ?>
-        </p>
-      <?php endif; ?>
-
-      <?php if ( empty( $tracking_code ) ) : ?>
-        <div class="pakettikauppa-services">
-          <fieldset class="pakettikauppa-metabox-fieldset">
-            <h4><?php esc_attr_e( 'Service', 'wc-pakettikauppa' ); ?></h4>
-            <?php foreach ( $active_shipping_options as $shipping_code => $shipping_settings ) : ?>
-              <?php if ( $shipping_settings['active'] === 'yes' ) : ?>
-                <label for="service-<?php echo esc_attr( $shipping_code ); ?>">
-                  <input type="radio"
-                    name="wc_pakettikauppa_service_id"
-                    value="<?php echo esc_attr( $shipping_code ); ?>"
-                    id="service-<?php echo esc_attr( $shipping_code ); ?>"
-                    <?php if ( $service_id === $shipping_code ) : ?>
-                      checked="checked";
-                    <?php endif; ?>
-                  />
-                  <span><?php echo esc_attr( $this->wc_pakettikauppa_shipment->service_title( $shipping_code ) ); ?></span>
-                </label>
-                <br>
-              <?php endif; ?>
-            <?php endforeach; ?>
-
-            <h4><?php esc_attr_e( 'Additional services', 'wc-pakettikauppa' ); ?></h4>
-            <input type="checkbox" name="wc_pakettikauppa_cod" value="1" id="wc-pakettikauppa-cod"
-            <?php if ( $cod ) : ?>
-              checked="checked"
-            <?php endif; ?> />
-            <label for="wc-pakettikauppa-cod"><?php esc_attr_e( 'Cash on Delivery', 'wc-pakettikauppa' ); ?></label>
-
-            <div class="form-field" id="wc-pakettikauppa-cod-amount-wrapper">
-              <label for="wc_pakettikauppa_cod_amount"><?php esc_attr_e( 'Amount (€):', 'wc-pakettikauppa' ); ?></label>
-              <input type="text" name="wc_pakettikauppa_cod_amount" value="<?php echo esc_attr( $cod_amount ); ?>" id="wc_pakettikauppa_cod_amount" />
-            </div>
-
-            <div class="form-field" id="wc-pakettikauppa-cod-reference-wrapper">
-              <label for="wc_pakettikauppa_cod_reference"><?php esc_attr_e( 'Reference:', 'wc-pakettikauppa' ); ?></label>
-              <input type="text" name="wc_pakettikauppa_cod_reference" value="<?php echo esc_attr( $cod_reference ); ?>" id="wc_pakettikauppa_cod_reference" />
-            </div>
-
-            <input type="checkbox" style="display:none;" name="wc_pakettikauppa_pickup_points" value="1" id="wc-pakettikauppa-pickup-points"
-            <?php if ( $pickup_point ) : ?>
-              checked="checked"
-            <?php endif; ?>
-            />
-
-            <?php
-            try {
-              $shipping_postcode  = $order->get_shipping_postcode();
-              $shipping_address_1 = $order->get_shipping_address_1();
-              $shipping_country   = $order->get_shipping_country();
-
-              if ( empty( $shipping_country ) ) {
-                $shipping_country = 'FI';
-              }
-
-              $pickup_points = array();
-
-              foreach ( $active_shipping_options as $shipping_code => $shipping_settings ) {
-                $shipping_provider = $this->wc_pakettikauppa_shipment->service_provider( $shipping_code );
-                $pickup_point_data = $this->wc_pakettikauppa_shipment->get_pickup_points( $shipping_postcode, $shipping_address_1, $shipping_country, $shipping_provider );
-                $pickup_points = array_merge( $pickup_points, json_decode( $pickup_point_data ) );
-              }
-              ?>
-
-              <div class="form-field" id="wc-pakettikauppa-pickup-points-wrapper">
-                <h4><?php esc_attr_e( 'Pickup Point', 'wc-pakettikauppa' ); ?></h4>
-                <select name="wc_pakettikauppa_pickup_point_id" class="wc_pakettikauppa_pickup_point_id" id="wc_pakettikauppa_pickup_point_id">
-                  <?php foreach ( $pickup_points as $key => $value ) : ?>
-                    <option value="<?php echo esc_attr( $value->pickup_point_id ); ?>"
-                      <?php if ( $pickup_point_id === $value->pickup_point_id ) : ?>
-                        selected
-                      <?php endif; ?>
-                      />
-                    <?php echo esc_attr( $value->provider . ': ' . $value->name . ' (' . $value->street_address . ')' ); ?></option>
-                  <?php endforeach; ?>
-                </select>
-              </div>
-
-            <?php
-            } catch ( Exception $e ) {
-              $this->add_error( $e->getMessage() );
-              echo '<p class="wc-pakettikauppa-metabox-error">'
-              . esc_attr__( 'Pickup point search failed! Check your error log for details.', 'wc-pakettikauppa' )
-              . '</p>';
-            }
-            ?>
-          </fieldset>
-
-        </div>
-        <p>
-          <input type="submit" value="<?php esc_attr_e( 'Create', 'wc-pakettikauppa' ); ?>" name="wc_pakettikauppa_create" class="button" />
-        </p>
-        <?php else : ?>
-          <p>
-            <input type="submit" value="<?php esc_attr_e( 'Update Status', 'wc-pakettikauppa' ); ?>" name="wc_pakettikauppa_get_status" class="button" />
-            <input type="submit" value="<?php esc_attr_e( 'Delete Shipping Label', 'wc-pakettikauppa' ); ?>" name="wc_pakettikauppa_delete_shipping_label"  class="button wc-pakettikauppa-delete-button" />
-          </p>
-        <?php endif; ?>
-      </div>
-
-    <?php
-  }
-
-  /**
-   * Save metabox values and fetch the shipping label for the order.
-   */
-  public function save_metabox( $post_id, $post ) {
-    if ( ! current_user_can( 'edit_post', $post_id ) ) {
-      return;
-    }
-
-    if ( wp_is_post_autosave( $post_id ) ) {
-      return;
-    }
-
-    if ( wp_is_post_revision( $post_id ) ) {
-      return;
-    }
-
-    if ( isset( $_POST['wc_pakettikauppa_create'] ) ) {
-
-      // Bail out if the receiver has not been properly configured
-      if ( ! WC_Pakettikauppa_Shipment::validate_order_shipping_receiver( wc_get_order( $post_id ) ) ) {
-        add_action( 'admin_notices', function() {
-          echo '<div class="update-nag notice">' .
-            esc_attr__( 'The shipping label was not created because the order does not contain valid shipping details.', 'wc-pakettikauppa' )
-            . '</div>';
-        });
-        return;
-      }
-
-      $order = new WC_Order( $post_id );
-
-      try {
-        $shipment_data = $this->wc_pakettikauppa_shipment->create_shipment( $post_id );
-
-        $document_url = admin_url( 'admin-post.php?post=' . $post_id . '&action=show_pakettikauppa&sid=' . $shipment_data['tracking_code'] );
-        $tracking_url = WC_Pakettikauppa_Shipment::tracking_url( $shipment_data['service_id'], $shipment_data['tracking_code'] );
-
-        // Add order note
-        $dl_link       = '<a href="' . $document_url . '" target="_blank">' . esc_attr__( 'Print document', 'wc-pakettikauppa' ) . '</a>';
-        $tracking_link = '<a href="' . $tracking_url . '" target="_blank">' . __( 'Track', 'wc-pakettikauppa' ) . '</a>';
-
-        $order->add_order_note( sprintf(
-          /* translators: 1: Shipping service title 2: Shipment tracking code 3: Shipping label URL 4: Shipment tracking URL */
-          __('Created Pakettikauppa %1$s shipment.<br>%2$s<br>%1$s - %3$s<br>%4$s', 'wc-pakettikauppa'),
-          $this->wc_pakettikauppa_shipment->service_title($shipment_data['service_id']),
-          $shipment_data['tracking_code'],
-          $dl_link,
-          $tracking_link
-        ));
-
-      } catch ( Exception $e ) {
-        $this->add_error( $e->getMessage() );
-        /* translators: %s: Error message */
-        $order->add_order_note( sprintf( esc_attr__('Failed to create Pakettikauppa shipment. Errors: %s', 'wc-pakettikauppa'), $e->getMessage() ) );
-        add_action( 'admin_notices', function() {
-          /* translators: %s: Error message */
-          $this->add_error_notice( wp_sprintf( esc_attr__( 'An error occured: %s', 'wc-pakettikauppa' ), $e->getMessage() ) );
-        });
-        return;
-      }
-    } elseif ( isset( $_POST['wc_pakettikauppa_get_status'] ) ) {
-      try {
-        $status_code = $this->wc_pakettikauppa_shipment->get_shipment_status( $post_id );
-        update_post_meta( $post_id, '_wc_pakettikauppa_shipment_status', $status_code );
-
-      } catch ( Exception $e ) {
-        $this->add_error( $e->getMessage() );
-        add_action( 'admin_notices', function() {
-          /* translators: %s: Error message */
-          $this->add_error_notice( wp_sprintf( esc_attr__( 'An error occured: %s', 'wc-pakettikauppa' ), $e->getMessage() ) );
-        });
-        return;
-      }
-    } elseif ( isset( $_POST['wc_pakettikauppa_delete_shipping_label'] ) ) {
-      try {
-        // Delete old shipping label
-        $this->delete_order_shipping_label( $post_id );
-        // Delete old tracking code
-        update_post_meta( $post_id, '_wc_pakettikauppa_tracking_code', '' );
-
-        $order = new WC_Order( $post_id );
-        $order->add_order_note( esc_attr__('Successfully deleted Pakettikauppa shipping label.', 'wc-pakettikauppa') );
-
-      } catch ( Exception $e ) {
-        $this->add_error( $e->getMessage() );
-        add_action( 'admin_notices', function() {
-          /* translators: %s: Error message */
-          $this->add_error_notice( wp_sprintf( esc_attr__( 'An error occured: %s', 'wc-pakettikauppa' ), $e->getMessage() ) );
-        });
-
-        $order = new WC_Order( $post_id );
-        $order->add_order_note(
-          sprintf(
-            /* translators: %s: Error message */
-            esc_attr__('Deleting Pakettikauppa shipment failed! Errors: %s', 'wc-pakettikauppa'),
-            $e->getMessage()
-          )
-        );
-      }
-    } else {
-      return;
-    }
-  }
-
-
-  /**
-   * Output shipment label as PDF in browser.
-   */
-  public function show() {
-    $shipment_id = false;
-
-    // Find shipment ID either from GET parameters or from the order
-    // data.
-    if ( isset( $_REQUEST['sid'] ) ) {
-      $shipment_id = $_REQUEST['sid'];
-    } else {
-      esc_attr_e( 'Shipment tracking code is not defined.', 'wc-pakettikauppa' );
-    }
-
-    if ( false !== $shipment_id ) {
-        $tracking_code = get_post_meta($post_id, '_wc_pakettikauppa_tracking_code', true);
-
-        $contents = $this->wc_pakettikauppa_shipment->fetchShippingLabel($tracking_code);
-      // Output
-      header('Content-type:application/pdf');
-      header("Content-Disposition:inline;filename={$tracking_code}.pdf");
-      print $contents;
-      exit;
-    }
-
-    esc_attr_e( 'Cannot find shipment with given shipment number.', 'wc-pakettikauppa' );
-    exit;
-  }
-
-  /**
-   * Attach tracking URL to email.
-   */
-  public function attach_tracking_to_email( $order, $sent_to_admin = false, $plain_text = false, $email = null ) {
-
-    $settings     = get_option( 'woocommerce_WC_Pakettikauppa_Shipping_Method_settings', null );
-    $add_to_email = $settings['add_tracking_to_email'];
-
-    if ( 'yes' === $add_to_email && isset( $email->id ) && 'customer_completed_order' === $email->id ) {
-
-      $tracking_code = get_post_meta( $order->get_ID(), '_wc_pakettikauppa_tracking_code', true );
-      $tracking_url  = WC_Pakettikauppa_Shipment::tracking_url( '', $tracking_code );
-
-      if ( ! empty( $tracking_code ) && ! empty( $tracking_url ) ) {
-        if ( $plain_text ) {
-          /* translators: %s: Shipment tracking URL */
-          echo sprintf( esc_html__( "You can track your order at %1$s.\n\n", 'wc-pakettikauppa' ), esc_url( $tracking_url ) );
-        } else {
-          echo '<h2>' . esc_attr__( 'Tracking', 'wc-pakettikauppa' ) . '</h2>';
-          /* translators: 1: Shipment tracking URL 2: Shipment tracking code */
-          echo '<p>' . sprintf( __( 'You can <a href="%1$s">track your order</a> with tracking code %2$s.', 'wc-pakettikauppa' ), esc_url( $tracking_url ), esc_attr( $tracking_code ) ) . '</p>';
+        } catch (Exception $e) {
+            $this->add_error($e->getMessage());
+            $this->add_error_notice($e->getMessage());
+            return;
         }
-      }
     }
-  }
 
-  /**
-   * Remove the shipping label of an order from the wc-pakettikauppa uploads directory
-   *
-   * @param int $post_id The post id of the order which is to be deleted
-   */
-  public function delete_order_shipping_label( $post_id ) {
-    // Check that the post type is order
-    $post_type = get_post_type( $post_id );
-    if ( $post_type !== 'shop_order' ) {
-      return;
+    /**
+     * Check if the selected service has pickup points via wp_ajax
+     */
+    public function update_meta_box_pickup_points()
+    {
+        if (isset($_POST) && !empty($_POST['service_id'])) {
+            $service_id = $_POST['service_id'];
+            echo esc_attr(WC_Pakettikauppa_Shipment::service_has_pickup_points($service_id));
+            wp_die();
+        }
     }
-  }
+
+    /**
+     * Add an error with a specified error message.
+     *
+     * @param string $message A message containing details about the error.
+     */
+    public function add_error($message)
+    {
+        if (!empty($message)) {
+            array_push($this->errors, $message);
+            error_log($message);
+        }
+    }
+
+    /**
+     * Return all errors that have been added via add_error().
+     *
+     * @return array Errors
+     */
+    public function get_errors()
+    {
+        return $this->errors;
+    }
+
+    /**
+     * Clear all existing errors that have been added via add_error().
+     */
+    public function clear_errors()
+    {
+        unset($this->errors);
+        $this->errors = array();
+    }
+
+    /**
+     * Add an admin error notice to wp-admin.
+     */
+    public function add_error_notice($message)
+    {
+        if (!empty($message)) {
+            $class = 'notice notice-error';
+            /* translators: %s: Error message */
+            $print_error = wp_sprintf(__('An error occured: %s', 'wc-pakettikauppa'), $message);
+            printf('<div class="%1$s"><p>%2$s</p></div>', esc_attr($class), esc_html($print_error));
+        }
+    }
+
+    /**
+     * Show row meta on the plugin screen.
+     *
+     * @param  mixed $links Plugin Row Meta
+     * @param  mixed $file Plugin Base file
+     * @return  array
+     */
+    public static function plugin_row_meta($links, $file)
+    {
+        if (WC_PAKETTIKAUPPA_BASENAME === $file) {
+            $row_meta = array(
+                'service' => '<a href="' . esc_url('https://www.pakettikauppa.fi') .
+                    '" aria-label="' . esc_attr__('Visit Pakettikauppa', 'wc-pakettikauppa') .
+                    '">' . esc_html__('Show site Pakettikauppa', 'wc-pakettikauppa') . '</a>',
+            );
+            return array_merge($links, $row_meta);
+        }
+        return (array)$links;
+    }
+
+    /**
+     * Register meta boxes for WooCommerce order metapage.
+     */
+    public function register_meta_boxes()
+    {
+        foreach (wc_get_order_types('order-meta-boxes') as $type) {
+            $order_type_object = get_post_type_object($type);
+            add_meta_box(
+                'wc-pakettikauppa',
+                esc_attr__('Pakettikauppa', 'wc-pakettikauppa'),
+                array(
+                    $this,
+                    'meta_box',
+                ),
+                $type,
+                'side',
+                'default'
+            );
+        }
+    }
+
+    /**
+     * Enqueue admin-specific styles and scripts.
+     */
+    public function admin_enqueue_scripts()
+    {
+        wp_enqueue_style('wc_pakettikauppa_admin', plugin_dir_url(__FILE__) . '../assets/css/wc-pakettikauppa-admin.css');
+        wp_enqueue_script('wc_pakettikauppa_admin_js', plugin_dir_url(__FILE__) . '../assets/js/wc-pakettikauppa-admin.js', array('jquery'));
+    }
+
+    /**
+     * Add settings link to the Pakettikauppa metabox on the plugins page when used with
+     * the WordPress hook plugin_action_links_woocommerce-pakettikauppa.
+     *
+     * @param array $links Already existing links on the plugin metabox
+     * @return array The plugin settings page link appended to the already existing links
+     */
+    public function add_settings_link($links)
+    {
+        $url = admin_url('admin.php?page=wc-settings&tab=shipping&section=wc_pakettikauppa_shipping_method');
+        $link = '<a href="' . $url . '">' . esc_attr__('Settings') . '</a>';
+
+        return array_merge(array($link), $links);
+    }
+
+    /**
+     * Show the selected pickup point in admin order meta. Use together with the hook
+     * woocommerce_admin_order_data_after_shipping_address.
+     *
+     * @param WC_Order $order The order that is currently being viewed in wp-admin
+     */
+    public function show_pickup_point_in_admin_order_meta($order)
+    {
+        echo '<p class="form-field"><strong>' . esc_attr__('Requested pickup point', 'wc-pakettikauppa') . ':</strong><br>';
+        if ($order->get_meta('_pakettikauppa_pickup_point')) {
+            echo esc_attr($order->get_meta('_pakettikauppa_pickup_point'));
+            echo '<br>ID: ' . esc_attr($order->get_meta('_pakettikauppa_pickup_point_id'));
+        } else {
+            echo esc_attr__('None');
+        }
+        echo '</p>';
+    }
+
+    /**
+     * Meta box for managing shipments.
+     */
+    public function meta_box($post)
+    {
+        $order = wc_get_order($post->ID);
+
+        if (!WC_Pakettikauppa_Shipment::validate_order_shipping_receiver($order)) {
+            esc_attr_e('Please add shipping info to the order to manage Pakettikauppa shipments.', 'wc-pakettikauppa');
+            return;
+        }
+
+        // Get active services from active_shipping_options
+        $settings = get_option('woocommerce_WC_Pakettikauppa_Shipping_Method_settings', null);
+        $active_shipping_options = json_decode($settings['active_shipping_options'], true);
+
+        // The tracking code will only be available if the shipment label has been generated
+        $tracking_code = get_post_meta($post->ID, '_wc_pakettikauppa_tracking_code', true);
+        $cod = get_post_meta($post->ID, '_wc_pakettikauppa_cod', true);
+        $cod_amount = get_post_meta($post->ID, '_wc_pakettikauppa_cod_amount', true);
+        $cod_reference = get_post_meta($post->ID, '_wc_pakettikauppa_cod_reference', true);
+        $service_id = get_post_meta($post->ID, '_wc_pakettikauppa_service_id', true);
+
+        $shipping_methods = $order->get_shipping_methods();
+        $shipping_method = reset($shipping_methods);
+        $ids = explode(':', $shipping_method['method_id']);
+        if (isset($ids[1]) && !empty($ids[1])) {
+            $service_id = (int)$ids[1];
+        }
+
+        $pickup_point = $order->get_meta('_pakettikauppa_pickup_point');
+        $pickup_point_id = $order->get_meta('_pakettikauppa_pickup_point_id');
+        $status = get_post_meta($post->ID, '_wc_pakettikauppa_shipment_status', true);
+
+        // Set defaults
+        if (empty($cod)) {
+            $cod = ($order->get_payment_method() === 'cod');
+        }
+        if (empty($cod_amount)) {
+            $cod_amount = $order->get_total();
+        }
+        if (empty($cod_reference)) {
+            $cod_reference = WC_Pakettikauppa_Shipment::calculate_reference($post->ID);
+        }
+        if (empty($service_id)) {
+            $service_id = WC_Pakettikauppa_Shipment::get_default_service($post, $order);
+        }
+
+        $document_url = admin_url('admin-post.php?post=' . $post->ID . '&action=show_pakettikauppa&sid=' . $tracking_code);
+        $tracking_url = WC_Pakettikauppa_Shipment::tracking_url($service_id, $tracking_code);
+
+        ?>
+        <div>
+            <?php if (!empty($tracking_code)) : ?>
+                <p class="pakettikauppa-shipment">
+                    <strong>
+                        <?php
+                        printf(
+                            '%1$s<br>%2$s<br>%3$s',
+                            esc_attr($this->wc_pakettikauppa_shipment->service_title($service_id)),
+                            esc_attr($tracking_code),
+                            esc_attr(WC_Pakettikauppa_Shipment::get_status_text($status))
+                        );
+                        ?>
+                    </strong><br>
+
+                    <a href="<?php echo esc_url($document_url); ?>" target="_blank"
+                       class="download"><?php esc_attr_e('Print document', 'wc-pakettikauppa'); ?></a>&nbsp;-&nbsp;
+
+                    <?php if (!empty($tracking_url)) : ?>
+                        <a href="<?php echo esc_url($tracking_url); ?>" target="_blank"
+                           class="tracking"><?php esc_attr_e('Track', 'wc-pakettikauppa'); ?></a>
+                    <?php endif; ?>
+                </p>
+            <?php endif; ?>
+
+            <?php if (empty($tracking_code)) : ?>
+                <div class="pakettikauppa-services">
+                    <fieldset class="pakettikauppa-metabox-fieldset">
+                        <h4><?php esc_attr_e('Service', 'wc-pakettikauppa'); ?></h4>
+                        <?php foreach ($active_shipping_options as $shipping_code => $shipping_settings) : ?>
+                            <?php if ($shipping_settings['active'] === 'yes') : ?>
+                                <label for="service-<?php echo esc_attr($shipping_code); ?>">
+                                    <input type="radio"
+                                           name="wc_pakettikauppa_service_id"
+                                           value="<?php echo esc_attr($shipping_code); ?>"
+                                           id="service-<?php echo esc_attr($shipping_code); ?>"
+                                        <?php if ($service_id === $shipping_code) : ?>
+                                            checked="checked";
+                                        <?php endif; ?>
+                                    />
+                                    <span><?php echo esc_attr($this->wc_pakettikauppa_shipment->service_title($shipping_code)); ?></span>
+                                </label>
+                                <br>
+                            <?php endif; ?>
+                        <?php endforeach; ?>
+
+                        <h4><?php esc_attr_e('Additional services', 'wc-pakettikauppa'); ?></h4>
+                        <input type="checkbox" name="wc_pakettikauppa_cod" value="1" id="wc-pakettikauppa-cod"
+                            <?php if ($cod) : ?>
+                                checked="checked"
+                            <?php endif; ?> />
+                        <label for="wc-pakettikauppa-cod"><?php esc_attr_e('Cash on Delivery', 'wc-pakettikauppa'); ?></label>
+
+                        <div class="form-field" id="wc-pakettikauppa-cod-amount-wrapper">
+                            <label for="wc_pakettikauppa_cod_amount"><?php esc_attr_e('Amount (€):', 'wc-pakettikauppa'); ?></label>
+                            <input type="text" name="wc_pakettikauppa_cod_amount"
+                                   value="<?php echo esc_attr($cod_amount); ?>" id="wc_pakettikauppa_cod_amount"/>
+                        </div>
+
+                        <div class="form-field" id="wc-pakettikauppa-cod-reference-wrapper">
+                            <label for="wc_pakettikauppa_cod_reference"><?php esc_attr_e('Reference:', 'wc-pakettikauppa'); ?></label>
+                            <input type="text" name="wc_pakettikauppa_cod_reference"
+                                   value="<?php echo esc_attr($cod_reference); ?>" id="wc_pakettikauppa_cod_reference"/>
+                        </div>
+
+                        <input type="checkbox" style="display:none;" name="wc_pakettikauppa_pickup_points" value="1"
+                               id="wc-pakettikauppa-pickup-points"
+                            <?php if ($pickup_point) : ?>
+                                checked="checked"
+                            <?php endif; ?>
+                        />
+
+                        <?php
+                        try {
+                            $shipping_postcode = $order->get_shipping_postcode();
+                            $shipping_address_1 = $order->get_shipping_address_1();
+                            $shipping_country = $order->get_shipping_country();
+
+                            if (empty($shipping_country)) {
+                                $shipping_country = 'FI';
+                            }
+
+                            $pickup_points = array();
+
+                            foreach ($active_shipping_options as $shipping_code => $shipping_settings) {
+                                $shipping_provider = $this->wc_pakettikauppa_shipment->service_provider($shipping_code);
+                                $pickup_point_data = $this->wc_pakettikauppa_shipment->get_pickup_points($shipping_postcode, $shipping_address_1, $shipping_country, $shipping_provider);
+                                $pickup_points = array_merge($pickup_points, json_decode($pickup_point_data));
+                            }
+                            ?>
+
+                            <div class="form-field" id="wc-pakettikauppa-pickup-points-wrapper">
+                                <h4><?php esc_attr_e('Pickup Point', 'wc-pakettikauppa'); ?></h4>
+                                <select name="wc_pakettikauppa_pickup_point_id" class="wc_pakettikauppa_pickup_point_id"
+                                        id="wc_pakettikauppa_pickup_point_id">
+                                    <?php foreach ($pickup_points as $key => $value) : ?>
+                                        <option value="<?php echo esc_attr($value->pickup_point_id); ?>"
+                                            <?php if ($pickup_point_id === $value->pickup_point_id) : ?>
+                                                selected
+                                            <?php endif; ?>
+                                        />
+                                        <?php echo esc_attr($value->provider . ': ' . $value->name . ' (' . $value->street_address . ')'); ?></option>
+                                    <?php endforeach; ?>
+                                </select>
+                            </div>
+
+                            <?php
+                        } catch (Exception $e) {
+                            $this->add_error($e->getMessage());
+                            echo '<p class="wc-pakettikauppa-metabox-error">'
+                                . esc_attr__('Pickup point search failed! Check your error log for details.', 'wc-pakettikauppa')
+                                . '</p>';
+                        }
+                        ?>
+                    </fieldset>
+
+                </div>
+                <p>
+                    <input type="submit" value="<?php esc_attr_e('Create', 'wc-pakettikauppa'); ?>"
+                           name="wc_pakettikauppa_create" class="button"/>
+                </p>
+            <?php else : ?>
+                <p>
+                    <input type="submit" value="<?php esc_attr_e('Update Status', 'wc-pakettikauppa'); ?>"
+                           name="wc_pakettikauppa_get_status" class="button"/>
+                    <input type="submit" value="<?php esc_attr_e('Delete Shipping Label', 'wc-pakettikauppa'); ?>"
+                           name="wc_pakettikauppa_delete_shipping_label" class="button wc-pakettikauppa-delete-button"/>
+                </p>
+            <?php endif; ?>
+        </div>
+
+        <?php
+    }
+
+    /**
+     * Save metabox values and fetch the shipping label for the order.
+     */
+    public function save_metabox($post_id, $post)
+    {
+        if (!current_user_can('edit_post', $post_id)) {
+            return;
+        }
+
+        if (wp_is_post_autosave($post_id)) {
+            return;
+        }
+
+        if (wp_is_post_revision($post_id)) {
+            return;
+        }
+
+        if (isset($_POST['wc_pakettikauppa_create'])) {
+
+            // Bail out if the receiver has not been properly configured
+            if (!WC_Pakettikauppa_Shipment::validate_order_shipping_receiver(wc_get_order($post_id))) {
+                add_action('admin_notices', function () {
+                    echo '<div class="update-nag notice">' .
+                        esc_attr__('The shipping label was not created because the order does not contain valid shipping details.', 'wc-pakettikauppa')
+                        . '</div>';
+                });
+                return;
+            }
+
+            $order = new WC_Order($post_id);
+
+            try {
+                $shipment_data = $this->wc_pakettikauppa_shipment->create_shipment($post_id);
+
+                $document_url = admin_url('admin-post.php?post=' . $post_id . '&action=show_pakettikauppa&sid=' . $shipment_data['tracking_code']);
+                $tracking_url = WC_Pakettikauppa_Shipment::tracking_url($shipment_data['service_id'], $shipment_data['tracking_code']);
+
+                // Add order note
+                $dl_link = '<a href="' . $document_url . '" target="_blank">' . esc_attr__('Print document', 'wc-pakettikauppa') . '</a>';
+                $tracking_link = '<a href="' . $tracking_url . '" target="_blank">' . __('Track', 'wc-pakettikauppa') . '</a>';
+
+                $order->add_order_note(sprintf(
+                /* translators: 1: Shipping service title 2: Shipment tracking code 3: Shipping label URL 4: Shipment tracking URL */
+                    __('Created Pakettikauppa %1$s shipment.<br>%2$s<br>%1$s - %3$s<br>%4$s', 'wc-pakettikauppa'),
+                    $this->wc_pakettikauppa_shipment->service_title($shipment_data['service_id']),
+                    $shipment_data['tracking_code'],
+                    $dl_link,
+                    $tracking_link
+                ));
+
+            } catch (Exception $e) {
+                $this->add_error($e->getMessage());
+                /* translators: %s: Error message */
+                $order->add_order_note(sprintf(esc_attr__('Failed to create Pakettikauppa shipment. Errors: %s', 'wc-pakettikauppa'), $e->getMessage()));
+                add_action('admin_notices', function () {
+                    /* translators: %s: Error message */
+                    $this->add_error_notice(wp_sprintf(esc_attr__('An error occured: %s', 'wc-pakettikauppa'), $e->getMessage()));
+                });
+                return;
+            }
+        } elseif (isset($_POST['wc_pakettikauppa_get_status'])) {
+            try {
+                $status_code = $this->wc_pakettikauppa_shipment->get_shipment_status($post_id);
+                update_post_meta($post_id, '_wc_pakettikauppa_shipment_status', $status_code);
+
+            } catch (Exception $e) {
+                $this->add_error($e->getMessage());
+                add_action('admin_notices', function () {
+                    /* translators: %s: Error message */
+                    $this->add_error_notice(wp_sprintf(esc_attr__('An error occured: %s', 'wc-pakettikauppa'), $e->getMessage()));
+                });
+                return;
+            }
+        } elseif (isset($_POST['wc_pakettikauppa_delete_shipping_label'])) {
+            try {
+                // Delete old shipping label
+                $this->delete_order_shipping_label($post_id);
+                // Delete old tracking code
+                update_post_meta($post_id, '_wc_pakettikauppa_tracking_code', '');
+
+                $order = new WC_Order($post_id);
+                $order->add_order_note(esc_attr__('Successfully deleted Pakettikauppa shipping label.', 'wc-pakettikauppa'));
+
+            } catch (Exception $e) {
+                $this->add_error($e->getMessage());
+                add_action('admin_notices', function () {
+                    /* translators: %s: Error message */
+                    $this->add_error_notice(wp_sprintf(esc_attr__('An error occured: %s', 'wc-pakettikauppa'), $e->getMessage()));
+                });
+
+                $order = new WC_Order($post_id);
+                $order->add_order_note(
+                    sprintf(
+                    /* translators: %s: Error message */
+                        esc_attr__('Deleting Pakettikauppa shipment failed! Errors: %s', 'wc-pakettikauppa'),
+                        $e->getMessage()
+                    )
+                );
+            }
+        } else {
+            return;
+        }
+    }
+
+
+    /**
+     * Output shipment label as PDF in browser.
+     */
+    public function show()
+    {
+        $shipment_id = false;
+
+        // Find shipment ID either from GET parameters or from the order
+        // data.
+        if (isset($_REQUEST['sid'])) {
+            $shipment_id = $_REQUEST['sid'];
+        } else {
+            esc_attr_e('Shipment tracking code is not defined.', 'wc-pakettikauppa');
+        }
+
+        if (false !== $shipment_id) {
+            $tracking_code = get_post_meta($post_id, '_wc_pakettikauppa_tracking_code', true);
+
+            $contents = $this->wc_pakettikauppa_shipment->fetchShippingLabel($tracking_code);
+            // Output
+            header('Content-type:application/pdf');
+            header("Content-Disposition:inline;filename={$tracking_code}.pdf");
+            print $contents;
+            exit;
+        }
+
+        esc_attr_e('Cannot find shipment with given shipment number.', 'wc-pakettikauppa');
+        exit;
+    }
+
+    /**
+     * Attach tracking URL to email.
+     */
+    public function attach_tracking_to_email($order, $sent_to_admin = false, $plain_text = false, $email = null)
+    {
+
+        $settings = get_option('woocommerce_WC_Pakettikauppa_Shipping_Method_settings', null);
+        $add_to_email = $settings['add_tracking_to_email'];
+
+        if ('yes' === $add_to_email && isset($email->id) && 'customer_completed_order' === $email->id) {
+
+            $tracking_code = get_post_meta($order->get_ID(), '_wc_pakettikauppa_tracking_code', true);
+            $tracking_url = WC_Pakettikauppa_Shipment::tracking_url('', $tracking_code);
+
+            if (!empty($tracking_code) && !empty($tracking_url)) {
+                if ($plain_text) {
+                    /* translators: %s: Shipment tracking URL */
+                    echo sprintf(esc_html__("You can track your order at %1$s.\n\n", 'wc-pakettikauppa'), esc_url($tracking_url));
+                } else {
+                    echo '<h2>' . esc_attr__('Tracking', 'wc-pakettikauppa') . '</h2>';
+                    /* translators: 1: Shipment tracking URL 2: Shipment tracking code */
+                    echo '<p>' . sprintf(__('You can <a href="%1$s">track your order</a> with tracking code %2$s.', 'wc-pakettikauppa'), esc_url($tracking_url), esc_attr($tracking_code)) . '</p>';
+                }
+            }
+        }
+    }
+
+    /**
+     * Remove the shipping label of an order from the wc-pakettikauppa uploads directory
+     *
+     * @param int $post_id The post id of the order which is to be deleted
+     */
+    public function delete_order_shipping_label($post_id)
+    {
+        // Check that the post type is order
+        $post_type = get_post_type($post_id);
+        if ($post_type !== 'shop_order') {
+            return;
+        }
+    }
 
 }

--- a/includes/class-wc-pakettikauppa-admin.php
+++ b/includes/class-wc-pakettikauppa-admin.php
@@ -276,89 +276,26 @@ class WC_Pakettikauppa_Admin
                         <h4><?php esc_attr_e('Service', 'wc-pakettikauppa'); ?></h4>
                         <?php foreach ($active_shipping_options as $shipping_code => $shipping_settings) : ?>
                             <?php if ($shipping_settings['active'] === 'yes') : ?>
-                                <label for="service-<?php echo esc_attr($shipping_code); ?>">
+                                <?php if ($service_id === $shipping_code) : ?>
+                                    <label for="service-<?php echo esc_attr($shipping_code); ?>">
                                     <input type="radio"
                                            name="wc_pakettikauppa_service_id"
                                            value="<?php echo esc_attr($shipping_code); ?>"
                                            id="service-<?php echo esc_attr($shipping_code); ?>"
-                                        <?php if ($service_id === $shipping_code) : ?>
-                                            checked="checked";
-                                        <?php endif; ?>
+                                           checked="checked"
                                     />
                                     <span><?php echo esc_attr($this->wc_pakettikauppa_shipment->service_title($shipping_code)); ?></span>
                                 </label>
                                 <br>
+                                <?php endif; ?>
                             <?php endif; ?>
                         <?php endforeach; ?>
 
-                        <h4><?php esc_attr_e('Additional services', 'wc-pakettikauppa'); ?></h4>
-                        <input type="checkbox" name="wc_pakettikauppa_cod" value="1" id="wc-pakettikauppa-cod"
-                            <?php if ($cod) : ?>
-                                checked="checked"
-                            <?php endif; ?> />
-                        <label for="wc-pakettikauppa-cod"><?php esc_attr_e('Cash on Delivery', 'wc-pakettikauppa'); ?></label>
+                        <?php if($pickup_point): ?>
+                            <input type="hidden" name="wc_pakettikauppa_pickup_points" value="1">
+                            <input type="hidden" name="wc_pakettikauppa_pickup_point_id" value="<?php echo $pickup_point_id;?>">
+                        <?php endif; ?>
 
-                        <div class="form-field" id="wc-pakettikauppa-cod-amount-wrapper">
-                            <label for="wc_pakettikauppa_cod_amount"><?php esc_attr_e('Amount (€):', 'wc-pakettikauppa'); ?></label>
-                            <input type="text" name="wc_pakettikauppa_cod_amount"
-                                   value="<?php echo esc_attr($cod_amount); ?>" id="wc_pakettikauppa_cod_amount"/>
-                        </div>
-
-                        <div class="form-field" id="wc-pakettikauppa-cod-reference-wrapper">
-                            <label for="wc_pakettikauppa_cod_reference"><?php esc_attr_e('Reference:', 'wc-pakettikauppa'); ?></label>
-                            <input type="text" name="wc_pakettikauppa_cod_reference"
-                                   value="<?php echo esc_attr($cod_reference); ?>" id="wc_pakettikauppa_cod_reference"/>
-                        </div>
-
-                        <input type="checkbox" style="display:none;" name="wc_pakettikauppa_pickup_points" value="1"
-                               id="wc-pakettikauppa-pickup-points"
-                            <?php if ($pickup_point) : ?>
-                                checked="checked"
-                            <?php endif; ?>
-                        />
-
-                        <?php
-                        try {
-                            $shipping_postcode = $order->get_shipping_postcode();
-                            $shipping_address_1 = $order->get_shipping_address_1();
-                            $shipping_country = $order->get_shipping_country();
-
-                            if (empty($shipping_country)) {
-                                $shipping_country = 'FI';
-                            }
-
-                            $pickup_points = array();
-
-                            foreach ($active_shipping_options as $shipping_code => $shipping_settings) {
-                                $shipping_provider = $this->wc_pakettikauppa_shipment->service_provider($shipping_code);
-                                $pickup_point_data = $this->wc_pakettikauppa_shipment->get_pickup_points($shipping_postcode, $shipping_address_1, $shipping_country, $shipping_provider);
-                                $pickup_points = array_merge($pickup_points, json_decode($pickup_point_data));
-                            }
-                            ?>
-
-                            <div class="form-field" id="wc-pakettikauppa-pickup-points-wrapper">
-                                <h4><?php esc_attr_e('Pickup Point', 'wc-pakettikauppa'); ?></h4>
-                                <select name="wc_pakettikauppa_pickup_point_id" class="wc_pakettikauppa_pickup_point_id"
-                                        id="wc_pakettikauppa_pickup_point_id">
-                                    <?php foreach ($pickup_points as $key => $value) : ?>
-                                        <option value="<?php echo esc_attr($value->pickup_point_id); ?>"
-                                            <?php if ($pickup_point_id === $value->pickup_point_id) : ?>
-                                                selected
-                                            <?php endif; ?>
-                                        />
-                                        <?php echo esc_attr($value->provider . ': ' . $value->name . ' (' . $value->street_address . ')'); ?></option>
-                                    <?php endforeach; ?>
-                                </select>
-                            </div>
-
-                            <?php
-                        } catch (Exception $e) {
-                            $this->add_error($e->getMessage());
-                            echo '<p class="wc-pakettikauppa-metabox-error">'
-                                . esc_attr__('Pickup point search failed! Check your error log for details.', 'wc-pakettikauppa')
-                                . '</p>';
-                        }
-                        ?>
                     </fieldset>
 
                 </div>

--- a/includes/class-wc-pakettikauppa-shipment.php
+++ b/includes/class-wc-pakettikauppa-shipment.php
@@ -227,7 +227,9 @@ class WC_Pakettikauppa_Shipment
     {
         $services = array();
 
-        $shippingCountry = WC()->customer->get_shipping_country();
+        if (WC()->customer != null) {
+            $shippingCountry = WC()->customer->get_shipping_country();
+        }
 
         if($shippingCountry == null || $shippingCountry == '') {
             $shippingCountry = 'FI';

--- a/includes/class-wc-pakettikauppa-shipment.php
+++ b/includes/class-wc-pakettikauppa-shipment.php
@@ -205,7 +205,7 @@ class WC_Pakettikauppa_Shipment {
       $pickup_point_limit = intval( $this->wc_pakettikauppa_settings['pickup_points_search_limit'] );
     }
 
-    $pickup_point_data = $this->wc_pakettikauppa_client->searchPickupPoints( $postcode, $street_address, $country, $service_provider, $pickup_point_limit);
+    $pickup_point_data = $this->wc_pakettikauppa_client->searchPickupPoints( trim($postcode), trim($street_address), trim($country), $service_provider, $pickup_point_limit);
     if ( $pickup_point_data === 'Bad request' ) {
       throw new Exception( __( 'WC_Pakettikauppa: An error occured when searching pickup points.', 'wc-pakettikauppa' ) );
     }

--- a/includes/class-wc-pakettikauppa-shipment.php
+++ b/includes/class-wc-pakettikauppa-shipment.php
@@ -178,11 +178,6 @@ class WC_Pakettikauppa_Shipment
         }
 
         if (!empty($tracking_code)) {
-            $this->wc_pakettikauppa_client->fetchShippingLabel($shipment);
-            $upload_dir = wp_upload_dir();
-            $filepath = WC_PAKETTIKAUPPA_PRIVATE_DIR . '/' . $tracking_code . '.pdf';
-            file_put_contents($filepath, base64_decode($shipment->getPdf()));
-
             update_post_meta($post_id, '_wc_pakettikauppa_tracking_code', $tracking_code);
         }
 
@@ -192,6 +187,10 @@ class WC_Pakettikauppa_Shipment
             'tracking_code' => $tracking_code,
             'service_id' => $service_id,
         );
+    }
+
+    public function fetch_shipping_label($tracking_code) {
+        return $this->wc_pakettikauppa_client->fetchShippingLabels(array($shipment));
     }
 
     /**

--- a/includes/class-wc-pakettikauppa-shipment.php
+++ b/includes/class-wc-pakettikauppa-shipment.php
@@ -227,6 +227,12 @@ class WC_Pakettikauppa_Shipment
     {
         $services = array();
 
+        $shippingCountry = WC()->customer->get_shipping_country();
+
+        if($shippingCountry == null || $shippingCountry == '') {
+            $shippingCountry = 'FI';
+        }
+
         // @TODO: File bug upstream about result being string instead of object by default
         $transient_name = 'wc_pakettikauppa_shipping_methods';
         $transient_time = 86400; // 24 hours
@@ -234,12 +240,16 @@ class WC_Pakettikauppa_Shipment
 
         if (false === $all_shipping_methods) {
             $all_shipping_methods = json_decode($this->wc_pakettikauppa_client->listShippingMethods());
+
             set_transient($transient_name, $all_shipping_methods, $transient_time);
         }
+
         // List all available methods as shipping options on checkout page
         if (!empty($all_shipping_methods)) {
             foreach ($all_shipping_methods as $shipping_method) {
-                $services[$shipping_method->shipping_method_code] = sprintf('%1$s %2$s', $shipping_method->service_provider, $shipping_method->name);
+                if(in_array($shippingCountry, $shipping_method->supported_countries)) {
+                    $services[$shipping_method->shipping_method_code] = sprintf('%1$s %2$s', $shipping_method->service_provider, $shipping_method->name);
+                }
             }
         }
         return $services;

--- a/includes/class-wc-pakettikauppa-shipment.php
+++ b/includes/class-wc-pakettikauppa-shipment.php
@@ -190,7 +190,8 @@ class WC_Pakettikauppa_Shipment
     }
 
     public function fetch_shipping_label($tracking_code) {
-        return $this->wc_pakettikauppa_client->fetchShippingLabels(array($shipment));
+        return $this->wc_pakettikauppa_client->fetchShippingLabels(array($tracking_code));
+
     }
 
     /**

--- a/includes/class-wc-pakettikauppa-shipment.php
+++ b/includes/class-wc-pakettikauppa-shipment.php
@@ -125,6 +125,10 @@ class WC_Pakettikauppa_Shipment {
     $parcel = new Parcel();
     $parcel->setWeight( $this::order_weight( $order ) );
     $parcel->setVolume( $this::order_volume( $order ) );
+
+    if (isset($this->wc_pakettikauppa_settings['info_code']) && $this->wc_pakettikauppa_settings['info_code'] != null && $this->wc_pakettikauppa_settings['info_code'] != '') {
+        $parcel->setInfocode($this->wc_pakettikauppa_settings['info_code']);
+    }
     $shipment->addParcel( $parcel );
 
     $cod = false;

--- a/includes/class-wc-pakettikauppa-shipment.php
+++ b/includes/class-wc-pakettikauppa-shipment.php
@@ -4,8 +4,8 @@
  */
 
 // Prevent direct access to this script
-if ( ! defined( 'ABSPATH' ) ) {
-  exit;
+if (!defined('ABSPATH')) {
+    exit;
 }
 
 require_once WC_PAKETTIKAUPPA_DIR . 'vendor/autoload.php';
@@ -27,471 +27,488 @@ use Pakettikauppa\Client;
  * @package  woocommerce-pakettikauppa
  * @author Seravo
  */
-class WC_Pakettikauppa_Shipment {
-  private $wc_pakettikauppa_client   = null;
-  private $wc_pakettikauppa_settings = null;
+class WC_Pakettikauppa_Shipment
+{
+    private $wc_pakettikauppa_client = null;
+    private $wc_pakettikauppa_settings = null;
 
-  public function __construct() {
-    $this->id = 'wc_pakettikauppa_shipment';
-  }
+    public function __construct()
+    {
+        $this->id = 'wc_pakettikauppa_shipment';
+    }
 
-  public function load() {
-    // Use option from database directly as WC_Pakettikauppa_Shipping_Method object is not accessible here
-    $settings = get_option( 'woocommerce_WC_Pakettikauppa_Shipping_Method_settings', null );
+    public function load()
+    {
+        // Use option from database directly as WC_Pakettikauppa_Shipping_Method object is not accessible here
+        $settings = get_option('woocommerce_WC_Pakettikauppa_Shipping_Method_settings', null);
 
-    if ( false === $settings ) {
-    throw new Exception(
-         'WooCommerce Pakettikauppa:
+        if (false === $settings) {
+            throw new Exception(
+                'WooCommerce Pakettikauppa:
         woocommerce_WC_Pakettikauppa_Shipping_Method_settings was not
         found in the database!'
+            );
+        }
+
+        $this->wc_pakettikauppa_settings = $settings;
+
+        $account_number = $settings['account_number'];
+        $secret_key = $settings['secret_key'];
+        $mode = $settings['mode'];
+        $is_test_mode = ($mode === 'production' ? false : true);
+
+        $options_array = array(
+            'api_key' => $account_number,
+            'secret' => $secret_key,
+            'test_mode' => $is_test_mode,
+        );
+
+        $this->wc_pakettikauppa_client = new Pakettikauppa\Client($options_array);
+    }
+
+    /**
+     * Get the status of a shipment
+     *
+     * @param int $post_id The post id of the order to update status of
+     * @return int The status code of the shipment
+     */
+    public function get_shipment_status($post_id)
+    {
+        $tracking_code = get_post_meta($post_id, '_wc_pakettikauppa_tracking_code', true);
+
+        if (!empty($tracking_code)) {
+            $result = $this->wc_pakettikauppa_client->getShipmentStatus($tracking_code);
+
+            $data = json_decode($result);
+
+            if (!empty($data) && isset($data[0])) {
+                return $data[0]->{'status_code'};
+            }
+            return '';
+        }
+
+    }
+
+    /**
+     * Create Pakettikauppa shipment from order
+     *
+     * @param int $post_id The post id of the order to ship
+     * @return array Shipment details
+     */
+    public function create_shipment($post_id)
+    {
+        $shipment = new Shipment();
+        $service_id = $_REQUEST['wc_pakettikauppa_service_id'];
+        $shipment->setShippingMethod($service_id);
+
+        $sender = new Sender();
+        $sender->setName1($this->wc_pakettikauppa_settings['sender_name']);
+        $sender->setAddr1($this->wc_pakettikauppa_settings['sender_address']);
+        $sender->setPostcode($this->wc_pakettikauppa_settings['sender_postal_code']);
+        $sender->setCity($this->wc_pakettikauppa_settings['sender_city']);
+        $sender->setCountry('FI');
+        $shipment->setSender($sender);
+
+        $order = new WC_Order($post_id);
+
+        $receiver = new Receiver();
+        $receiver->setName1($order->get_formatted_shipping_full_name());
+        $receiver->setAddr1($order->get_shipping_address_1());
+        $receiver->setAddr2($order->get_shipping_address_2());
+        $receiver->setPostcode($order->get_shipping_postcode());
+        $receiver->setCity($order->get_shipping_city());
+        $receiver->setCountry('FI');
+        $receiver->setEmail($order->get_billing_email());
+        $receiver->setPhone($order->get_billing_phone());
+        $shipment->setReceiver($receiver);
+
+        $info = new Info();
+        $info->setReference($order->get_order_number());
+        $info->setCurrency(get_woocommerce_currency());
+        $shipment->setShipmentInfo($info);
+
+        $parcel = new Parcel();
+        $parcel->setWeight($this::order_weight($order));
+        $parcel->setVolume($this::order_volume($order));
+
+        if (isset($this->wc_pakettikauppa_settings['info_code']) && $this->wc_pakettikauppa_settings['info_code'] != null && $this->wc_pakettikauppa_settings['info_code'] != '') {
+            $parcel->setInfocode($this->wc_pakettikauppa_settings['info_code']);
+        }
+        $shipment->addParcel($parcel);
+
+        $cod = false;
+
+        if (isset($_REQUEST['wc_pakettikauppa_cod']) && $_REQUEST['wc_pakettikauppa_cod']) {
+            $cod = true;
+            $cod_amount = floatval(str_replace(',', '.', $_REQUEST['wc_pakettikauppa_cod_amount']));
+            $cod_reference = trim($_REQUEST['wc_pakettikauppa_cod_reference']);
+            $cod_iban = $this->wc_pakettikauppa_settings['cod_iban'];
+            $cod_bic = $this->wc_pakettikauppa_settings['cod_bic'];
+
+            $additional_service = new AdditionalService();
+            $additional_service->addSpecifier('amount', $cod_amount);
+            $additional_service->addSpecifier('account', $cod_iban);
+            $additional_service->addSpecifier('codbic', $cod_bic);
+            $additional_service->setServiceCode(3101);
+            $shipment->addAdditionalService($additional_service);
+
+            update_post_meta($post_id, '_wc_pakettikauppa_cod', $cod);
+            update_post_meta($post_id, '_wc_pakettikauppa_cod_amount', $cod_amount);
+            update_post_meta($post_id, '_wc_pakettikauppa_cod_reference', $cod_reference);
+        }
+
+        $pickup_point = false;
+        if (isset($_REQUEST['wc_pakettikauppa_pickup_points']) && $_REQUEST['wc_pakettikauppa_pickup_points']) {
+            $pickup_point = true;
+            $pickup_point_id = intval($_REQUEST['wc_pakettikauppa_pickup_point_id']);
+
+            $shipment->setPickupPoint($pickup_point_id);
+
+            update_post_meta($post_id, '_wc_pakettikauppa_pickup_point', $pickup_point);
+            update_post_meta($post_id, '_wc_pakettikauppa_pickup_point_id', $pickup_point_id);
+        }
+
+        try {
+            if ($this->wc_pakettikauppa_client->createTrackingCode($shipment)) {
+                $tracking_code = $shipment->getTrackingCode()->__toString();
+            }
+        } catch (Exception $e) {
+            /* translators: %s: Error message */
+            throw new Exception(wp_sprintf(__('WooCommerce Pakettikauppa: tracking code creation failed: %s', 'wc-pakettikauppa'), $e->getMessage()));
+        }
+
+        if (!empty($tracking_code)) {
+            $this->wc_pakettikauppa_client->fetchShippingLabel($shipment);
+            $upload_dir = wp_upload_dir();
+            $filepath = WC_PAKETTIKAUPPA_PRIVATE_DIR . '/' . $tracking_code . '.pdf';
+            file_put_contents($filepath, base64_decode($shipment->getPdf()));
+
+            update_post_meta($post_id, '_wc_pakettikauppa_tracking_code', $tracking_code);
+        }
+
+        update_post_meta($post_id, '_wc_pakettikauppa_service_id', $service_id);
+
+        return array(
+            'tracking_code' => $tracking_code,
+            'service_id' => $service_id,
         );
     }
 
-    $this->wc_pakettikauppa_settings = $settings;
+    /**
+     * Return pickup points near a location specified by the parameters.
+     *
+     * @param int $postcode The postcode of the pickup point
+     * @param string $street_address The street address of the pickup point
+     * @param string $country The country in which the pickup point is located
+     * @param string $service_provider A service that should be provided by the pickup point
+     * @return array The pickup points based on the parameters, or empty array if none were found
+     */
+    public function get_pickup_points($postcode, $street_address = null, $country = null, $service_provider = null)
+    {
+        $pickup_point_limit = 5; // Default limit value for pickup point search
 
-    $account_number = $settings['account_number'];
-    $secret_key     = $settings['secret_key'];
-    $mode           = $settings['mode'];
-    $is_test_mode   = ( $mode === 'production' ? false : true );
-
-    $options_array = array(
-		'api_key'   => $account_number,
-		'secret'    => $secret_key,
-		'test_mode' => $is_test_mode,
-    );
-
-    $this->wc_pakettikauppa_client = new Pakettikauppa\Client( $options_array );
-  }
-
-  /**
-   * Get the status of a shipment
-   *
-   * @param int $post_id The post id of the order to update status of
-   * @return int The status code of the shipment
-   */
-  public function get_shipment_status( $post_id ) {
-    $tracking_code = get_post_meta( $post_id, '_wc_pakettikauppa_tracking_code', true);
-
-    if ( ! empty( $tracking_code ) ) {
-      $result = $this->wc_pakettikauppa_client->getShipmentStatus($tracking_code);
-
-      $data = json_decode( $result );
-
-      if ( ! empty( $data ) && isset( $data[0] ) ) {
-        return $data[0]->{'status_code'};
-      }
-      return '';
-    }
-
-  }
-
-  /**
-   * Create Pakettikauppa shipment from order
-   *
-   * @param int $post_id The post id of the order to ship
-   * @return array Shipment details
-   */
-  public function create_shipment( $post_id ) {
-    $shipment   = new Shipment();
-    $service_id = $_REQUEST['wc_pakettikauppa_service_id'];
-    $shipment->setShippingMethod( $service_id );
-
-    $sender = new Sender();
-    $sender->setName1( $this->wc_pakettikauppa_settings['sender_name'] );
-    $sender->setAddr1( $this->wc_pakettikauppa_settings['sender_address'] );
-    $sender->setPostcode( $this->wc_pakettikauppa_settings['sender_postal_code'] );
-    $sender->setCity( $this->wc_pakettikauppa_settings['sender_city'] );
-    $sender->setCountry( 'FI' );
-    $shipment->setSender($sender);
-
-    $order = new WC_Order( $post_id );
-
-    $receiver = new Receiver();
-    $receiver->setName1( $order->get_formatted_shipping_full_name() );
-    $receiver->setAddr1( $order->get_shipping_address_1() );
-    $receiver->setAddr2( $order->get_shipping_address_2() );
-    $receiver->setPostcode( $order->get_shipping_postcode() );
-    $receiver->setCity( $order->get_shipping_city() );
-    $receiver->setCountry('FI');
-    $receiver->setEmail( $order->get_billing_email() );
-    $receiver->setPhone( $order->get_billing_phone() );
-    $shipment->setReceiver( $receiver );
-
-    $info = new Info();
-    $info->setReference( $order->get_order_number() );
-    $info->setCurrency( get_woocommerce_currency() );
-    $shipment->setShipmentInfo( $info );
-
-    $parcel = new Parcel();
-    $parcel->setWeight( $this::order_weight( $order ) );
-    $parcel->setVolume( $this::order_volume( $order ) );
-
-    if (isset($this->wc_pakettikauppa_settings['info_code']) && $this->wc_pakettikauppa_settings['info_code'] != null && $this->wc_pakettikauppa_settings['info_code'] != '') {
-        $parcel->setInfocode($this->wc_pakettikauppa_settings['info_code']);
-    }
-    $shipment->addParcel( $parcel );
-
-    $cod = false;
-
-    if ( isset( $_REQUEST['wc_pakettikauppa_cod'] ) && $_REQUEST['wc_pakettikauppa_cod'] ) {
-      $cod           = true;
-      $cod_amount    = floatval( str_replace( ',', '.', $_REQUEST['wc_pakettikauppa_cod_amount'] ) );
-      $cod_reference = trim( $_REQUEST['wc_pakettikauppa_cod_reference'] );
-      $cod_iban      = $this->wc_pakettikauppa_settings['cod_iban'];
-      $cod_bic       = $this->wc_pakettikauppa_settings['cod_bic'];
-
-      $additional_service = new AdditionalService();
-      $additional_service->addSpecifier( 'amount', $cod_amount );
-      $additional_service->addSpecifier( 'account', $cod_iban );
-      $additional_service->addSpecifier( 'codbic', $cod_bic );
-      $additional_service->setServiceCode( 3101 );
-      $shipment->addAdditionalService($additional_service);
-
-      update_post_meta( $post_id, '_wc_pakettikauppa_cod', $cod);
-      update_post_meta( $post_id, '_wc_pakettikauppa_cod_amount', $cod_amount);
-      update_post_meta( $post_id, '_wc_pakettikauppa_cod_reference', $cod_reference);
-    }
-
-    $pickup_point = false;
-    if ( isset( $_REQUEST['wc_pakettikauppa_pickup_points'] ) && $_REQUEST['wc_pakettikauppa_pickup_points'] ) {
-      $pickup_point    = true;
-      $pickup_point_id = intval( $_REQUEST['wc_pakettikauppa_pickup_point_id'] );
-
-      $shipment->setPickupPoint( $pickup_point_id );
-
-      update_post_meta( $post_id, '_wc_pakettikauppa_pickup_point', $pickup_point);
-      update_post_meta( $post_id, '_wc_pakettikauppa_pickup_point_id', $pickup_point_id);
-    }
-
-    try {
-      if ( $this->wc_pakettikauppa_client->createTrackingCode($shipment) ) {
-        $tracking_code = $shipment->getTrackingCode()->__toString();
-      }
-    } catch ( Exception $e ) {
-      /* translators: %s: Error message */
-      throw new Exception( wp_sprintf( __( 'WooCommerce Pakettikauppa: tracking code creation failed: %s', 'wc-pakettikauppa' ), $e->getMessage() ) );
-    }
-
-    if ( ! empty( $tracking_code ) ) {
-      $this->wc_pakettikauppa_client->fetchShippingLabel( $shipment );
-      $upload_dir = wp_upload_dir();
-      $filepath   = WC_PAKETTIKAUPPA_PRIVATE_DIR . '/' . $tracking_code . '.pdf';
-      file_put_contents( $filepath, base64_decode( $shipment->getPdf() ) );
-
-      update_post_meta( $post_id, '_wc_pakettikauppa_tracking_code', $tracking_code );
-    }
-
-    update_post_meta( $post_id, '_wc_pakettikauppa_service_id', $service_id );
-
-    return array(
-		'tracking_code' => $tracking_code,
-		'service_id'    => $service_id,
-    );
-  }
-
-  /**
-   * Return pickup points near a location specified by the parameters.
-   *
-   * @param int $postcode The postcode of the pickup point
-   * @param string $street_address The street address of the pickup point
-   * @param string $country The country in which the pickup point is located
-   * @param string $service_provider A service that should be provided by the pickup point
-   * @return array The pickup points based on the parameters, or empty array if none were found
-   */
-  public function get_pickup_points( $postcode, $street_address = null, $country = null, $service_provider = null ) {
-    $pickup_point_limit = 5; // Default limit value for pickup point search
-
-    if ( isset( $this->wc_pakettikauppa_settings['pickup_points_search_limit'] ) && ! empty( $this->wc_pakettikauppa_settings['pickup_points_search_limit'] ) ) {
-      $pickup_point_limit = intval( $this->wc_pakettikauppa_settings['pickup_points_search_limit'] );
-    }
-
-    $pickup_point_data = $this->wc_pakettikauppa_client->searchPickupPoints( trim($postcode), trim($street_address), trim($country), $service_provider, $pickup_point_limit);
-    if ( $pickup_point_data === 'Bad request' ) {
-      throw new Exception( __( 'WC_Pakettikauppa: An error occured when searching pickup points.', 'wc-pakettikauppa' ) );
-    }
-    return $pickup_point_data;
-  }
-
-  /**
-   * Get all available shipping services.
-   *
-   * @return array Available shipping services
-   */
-  public function services() {
-    $services = array();
-
-    // @TODO: File bug upstream about result being string instead of object by default
-    $transient_name       = 'wc_pakettikauppa_shipping_methods';
-    $transent_time        = 86400; // 24 hours
-    $all_shipping_methods = get_transient( $transient_name );
-
-    if ( false === $all_shipping_methods ) {
-      $all_shipping_methods = json_decode( $this->wc_pakettikauppa_client->listShippingMethods() );
-      set_transient( $transient_name, $all_shipping_methods, $transient_time );
-    }
-    // List all available methods as shipping options on checkout page
-    if ( ! empty( $all_shipping_methods ) ) {
-      foreach ( $all_shipping_methods as $shipping_method ) {
-        $services[$shipping_method->shipping_method_code] = sprintf( '%1$s %2$s', $shipping_method->service_provider, $shipping_method->name );
-      }
-    }
-    return $services;
-  }
-
-  /**
-   * Get the title of a service by providing its code.
-   *
-   * @param int $service_code The code of a service
-   * @return string The service title matching with the provided code, or false if not found
-   */
-  public function service_title( $service_code ) {
-    $services = $this->services();
-    if ( isset( $services[$service_code] ) ) {
-      return $services[$service_code];
-    }
-
-    return false;
-  }
-
-  /**
-   * Get the provider of a service by providing its code.
-   *
-   * @param int $service_code The code of a service
-   * @return string The service provider matching with the provided code, or false if not found
-   */
-  public function service_provider( $service_code ) {
-    $services = array();
-
-    $transient_name       = 'wc_pakettikauppa_shipping_methods';
-    $transent_time        = 86400; // 24 hours
-    $all_shipping_methods = get_transient( $transient_name );
-
-    if ( false === $all_shipping_methods ) {
-      try {
-        $all_shipping_methods = json_decode( $this->wc_pakettikauppa_client->listShippingMethods() );
-        set_transient( $transient_name, $all_shipping_methods, $transient_time );
-
-      } catch ( Exception $e ) {
-        /* translators: %s: Error message */
-        throw new Exception( wp_sprintf( __( 'WooCommerce Pakettikauppa: an error occured when accessing service providers: %s', 'wc-pakettikauppa' ), $e->getMessage() ) );
-      }
-    }
-
-    if ( ! empty( $all_shipping_methods ) ) {
-      foreach ( $all_shipping_methods as $shipping_method ) {
-        if ( intval($service_code) === intval($shipping_method->shipping_method_code) ) {
-          return $shipping_method->service_provider;
+        if (isset($this->wc_pakettikauppa_settings['pickup_points_search_limit']) && !empty($this->wc_pakettikauppa_settings['pickup_points_search_limit'])) {
+            $pickup_point_limit = intval($this->wc_pakettikauppa_settings['pickup_points_search_limit']);
         }
-      }
-     }
-     return false;
-   }
 
-  /**
-   * Get the status text of a shipment that matches a specified status code.
-   *
-   * @param int $status_code A status code
-   * @return string The status text matching the provided code, or unknown status if the
-   * code is unknown.
-   */
-  public static function get_status_text( $status_code ) {
-    $status = '';
-
-    switch ( intval($status_code) ) {
-      case 13:
-        $status = __( 'Item is collected from sender - picked up', 'wc-pakettikauppa' );
-        break;
-      case 20:
-        $status = __( 'Exception', 'wc-pakettikauppa' );
-        break;
-      case 22:
-        $status = __( 'Item has been handed over to the recipient', 'wc-pakettikauppa' );
-        break;
-      case 31:
-        $status = __( 'Item is in transport', 'wc-pakettikauppa' );
-        break;
-      case 38:
-        $status = __( 'C.O.D payment is paid to the sender', 'wc-pakettikauppa' );
-        break;
-      case 45:
-        $status = __( 'Informed consignee of arrival', 'wc-pakettikauppa' );
-        break;
-      case 48:
-        $status = __( 'Item is loaded onto a means of transport', 'wc-pakettikauppa' );
-        break;
-      case 56:
-        $status = __( 'Item not delivered – delivery attempt made', 'wc-pakettikauppa' );
-        break;
-      case 68:
-        $status = __( 'Pre-information is received from sender', 'wc-pakettikauppa' );
-        break;
-      case 71:
-        $status = __( 'Item is ready for delivery transportation', 'wc-pakettikauppa');
-        break;
-      case 77:
-        $status = __( 'Item is returning to the sender', 'wc-pakettikauppa' );
-        break;
-      case 91:
-        $status = __( 'Item is arrived to a post office', 'wc-pakettikauppa' );
-        break;
-      case 99:
-        $status = __( 'Outbound', 'wc-pakettikauppa' );
-        break;
-      default:
-        /* translators: %s: Status code */
-        $status = wp_sprintf( __( 'Unknown status: %s', 'wc-pakettikauppa' ), $status_code );
-        break;
-    }
-
-    return $status;
-  }
-
-  /**
-   * Calculate the total shipping weight of an order.
-   *
-   * @param WC_Order $order The order to calculate the weight of
-   * @return int The total weight of the order
-   */
-  public static function order_weight( $order ) {
-    $weight = 0;
-
-    if ( count( $order->get_items() ) > 0 ) {
-      foreach ( $order->get_items() as $item ) {
-        if ( $item['product_id'] > 0 ) {
-          $product = $order->get_product_from_item( $item );
-          if ( ! $product->is_virtual() ) {
-            $weight += wc_get_weight($product->get_weight() * $item['qty'], 'kg');
-          }
+        $pickup_point_data = $this->wc_pakettikauppa_client->searchPickupPoints(trim($postcode), trim($street_address), trim($country), $service_provider, $pickup_point_limit);
+        if ($pickup_point_data === 'Bad request') {
+            throw new Exception(__('WC_Pakettikauppa: An error occured when searching pickup points.', 'wc-pakettikauppa'));
         }
-      }
+        return $pickup_point_data;
     }
 
-    return $weight;
-  }
+    /**
+     * Get all available shipping services.
+     *
+     * @return array Available shipping services
+     */
+    public function services()
+    {
+        $services = array();
 
-  /**
-   * Calculate the total shipping volume of an order in cubic meters.
-   *
-   * @param WC_Order $order The order to calculate the volume of
-   * @return int The total volume of the order (m^3)
-   */
-  public static function order_volume( $order ) {
-    $volume = 0;
+        // @TODO: File bug upstream about result being string instead of object by default
+        $transient_name = 'wc_pakettikauppa_shipping_methods';
+        $transent_time = 86400; // 24 hours
+        $all_shipping_methods = get_transient($transient_name);
 
-    if ( count( $order->get_items() ) > 0 ) {
-      foreach ( $order->get_items() as $item ) {
-        if ( $item['product_id'] > 0 ) {
-          $product = $order->get_product_from_item( $item );
-          if ( ! $product->is_virtual() ) {
-            // Ensure that the volume is in metres
-            $woo_dim_unit = strtolower( get_option('woocommerce_dimension_unit') );
-            switch ( $woo_dim_unit ) {
-              case 'mm':
-                $dim_multiplier = 0.001;
-                break;
-              case 'cm':
-                $dim_multiplier = 0.01;
-                break;
-              case 'dm':
-                $dim_multiplier = 0.1;
-                break;
-              default:
-                $dim_multiplier = 1;
+        if (false === $all_shipping_methods) {
+            $all_shipping_methods = json_decode($this->wc_pakettikauppa_client->listShippingMethods());
+            set_transient($transient_name, $all_shipping_methods, $transient_time);
+        }
+        // List all available methods as shipping options on checkout page
+        if (!empty($all_shipping_methods)) {
+            foreach ($all_shipping_methods as $shipping_method) {
+                $services[$shipping_method->shipping_method_code] = sprintf('%1$s %2$s', $shipping_method->service_provider, $shipping_method->name);
             }
-            // Calculate total volume
-            $volume += pow($dim_multiplier, 3) * $product->get_width()
-              * $product->get_height() * $product->get_length() * $item['qty'];
-          }
         }
-      }
+        return $services;
     }
 
-    return $volume;
-  }
+    /**
+     * Get the title of a service by providing its code.
+     *
+     * @param int $service_code The code of a service
+     * @return string The service title matching with the provided code, or false if not found
+     */
+    public function service_title($service_code)
+    {
+        $services = $this->services();
+        if (isset($services[$service_code])) {
+            return $services[$service_code];
+        }
 
-  /**
-   * Get the full-length tracking url of a shipment by providing its service id and tracking code.
-   * Use tracking url provided by pakettikauppa.fi.
-   *
-   * @param int $service_id The id of the service that is used for the shipment
-   * @param int $tracking_code The tracking code of the shipment
-   * @return string The full tracking url for the order
-   */
-  public static function tracking_url( $service_id, $tracking_code ) {
-    $tracking_url = 'https://www.pakettikauppa.fi/seuranta/?' . $tracking_code;
-    return $tracking_url;
-  }
-
-  /**
-   * Calculate Finnish invoice reference from order ID
-   * http://tarkistusmerkit.teppovuori.fi/tarkmerk.htm#viitenumero
-   *
-   * @param int $id The id of the order to calculate the reference of
-   * @return int The reference number calculated from the id
-   */
-  public static function calculate_reference( $id ) {
-    $weights              = array( 7, 3, 1, 7, 3, 1, 7, 3, 1, 7, 3, 1, 7, 3, 1, 7, 3, 1, 7 );
-    $base                 = str_split( strval( ( $id + 100 ) ) );
-    $reversed_base        = array_reverse( $base );
-    $sum                  = 0;
-    $reversed_base_length = count( $reversed_base );
-
-    for ( $i = 0; $i < $reversed_base_length; $i++ ) {
-      $coefficient = array_shift( $weights );
-      $sum        += $reversed_base[$i] * $coefficient;
+        return false;
     }
 
-    $checksum = ( $sum % 10 === 0 ) ? 0 : ( 10 - $sum % 10 );
+    /**
+     * Get the provider of a service by providing its code.
+     *
+     * @param int $service_code The code of a service
+     * @return string The service provider matching with the provided code, or false if not found
+     */
+    public function service_provider($service_code)
+    {
+        $services = array();
 
-    $reference = implode( '', $base ) . $checksum;
-    return $reference;
-  }
+        $transient_name = 'wc_pakettikauppa_shipping_methods';
+        $transent_time = 86400; // 24 hours
+        $all_shipping_methods = get_transient($transient_name);
 
-  /**
-   * Return the default shipping service if none has been specified
-   *
-   * @TODO: Does this method really need $post or $order, as the default service should
-   * not be order-specific?
-   */
-  public static function get_default_service( $post, $order ) {
-    // @TODO: Maybe use an option in database so the merchant can set it in settings
-    $service = '2103';
-    return $service;
-  }
+        if (false === $all_shipping_methods) {
+            try {
+                $all_shipping_methods = json_decode($this->wc_pakettikauppa_client->listShippingMethods());
+                set_transient($transient_name, $all_shipping_methods, $transient_time);
 
-  /**
-   * Validate order details in wp-admin. Especially useful, when creating orders in wp-admin,
-   *
-   * @param WC_Order $order The order that needs its info to be validated
-   * @return True, if the details where valid, or false if not
-   */
-  public static function validate_order_shipping_receiver( $order ) {
-    // Check shipping info first
-    $no_shipping_name     = (bool) empty( $order->get_formatted_shipping_full_name() );
-    $no_shipping_address  = (bool) empty( $order->get_shipping_address_1() ) && empty( $order->get_shipping_address_2() );
-    $no_shipping_postcode = (bool) empty( $order->get_shipping_postcode() );
-    $no_shipping_city     = (bool) empty( $order->get_shipping_city() );
+            } catch (Exception $e) {
+                /* translators: %s: Error message */
+                throw new Exception(wp_sprintf(__('WooCommerce Pakettikauppa: an error occured when accessing service providers: %s', 'wc-pakettikauppa'), $e->getMessage()));
+            }
+        }
 
-    if ( $no_shipping_name || $no_shipping_address || $no_shipping_postcode || $no_shipping_city ) {
-      return false;
+        if (!empty($all_shipping_methods)) {
+            foreach ($all_shipping_methods as $shipping_method) {
+                if (intval($service_code) === intval($shipping_method->shipping_method_code)) {
+                    return $shipping_method->service_provider;
+                }
+            }
+        }
+        return false;
     }
-    return true;
-  }
 
-  public static function service_has_pickup_points( $service_id ) {
-    // @TODO: Find out if the Pakettikauppa API can be used to check if the service uses
-    // pickup points instead of hard coding them here.
-    $services_with_pickup_points = array(
-      '2103',
-      '80010',
-      '90010',
-      '90080',
-    );
+    /**
+     * Get the status text of a shipment that matches a specified status code.
+     *
+     * @param int $status_code A status code
+     * @return string The status text matching the provided code, or unknown status if the
+     * code is unknown.
+     */
+    public static function get_status_text($status_code)
+    {
+        $status = '';
 
-    if ( in_array( $service_id, $services_with_pickup_points, true ) ) {
-      return true;
+        switch (intval($status_code)) {
+            case 13:
+                $status = __('Item is collected from sender - picked up', 'wc-pakettikauppa');
+                break;
+            case 20:
+                $status = __('Exception', 'wc-pakettikauppa');
+                break;
+            case 22:
+                $status = __('Item has been handed over to the recipient', 'wc-pakettikauppa');
+                break;
+            case 31:
+                $status = __('Item is in transport', 'wc-pakettikauppa');
+                break;
+            case 38:
+                $status = __('C.O.D payment is paid to the sender', 'wc-pakettikauppa');
+                break;
+            case 45:
+                $status = __('Informed consignee of arrival', 'wc-pakettikauppa');
+                break;
+            case 48:
+                $status = __('Item is loaded onto a means of transport', 'wc-pakettikauppa');
+                break;
+            case 56:
+                $status = __('Item not delivered – delivery attempt made', 'wc-pakettikauppa');
+                break;
+            case 68:
+                $status = __('Pre-information is received from sender', 'wc-pakettikauppa');
+                break;
+            case 71:
+                $status = __('Item is ready for delivery transportation', 'wc-pakettikauppa');
+                break;
+            case 77:
+                $status = __('Item is returning to the sender', 'wc-pakettikauppa');
+                break;
+            case 91:
+                $status = __('Item is arrived to a post office', 'wc-pakettikauppa');
+                break;
+            case 99:
+                $status = __('Outbound', 'wc-pakettikauppa');
+                break;
+            default:
+                /* translators: %s: Status code */
+                $status = wp_sprintf(__('Unknown status: %s', 'wc-pakettikauppa'), $status_code);
+                break;
+        }
+
+        return $status;
     }
-    return false;
-  }
+
+    /**
+     * Calculate the total shipping weight of an order.
+     *
+     * @param WC_Order $order The order to calculate the weight of
+     * @return int The total weight of the order
+     */
+    public static function order_weight($order)
+    {
+        $weight = 0;
+
+        if (count($order->get_items()) > 0) {
+            foreach ($order->get_items() as $item) {
+                if ($item['product_id'] > 0) {
+                    $product = $order->get_product_from_item($item);
+                    if (!$product->is_virtual()) {
+                        $weight += wc_get_weight($product->get_weight() * $item['qty'], 'kg');
+                    }
+                }
+            }
+        }
+
+        return $weight;
+    }
+
+    /**
+     * Calculate the total shipping volume of an order in cubic meters.
+     *
+     * @param WC_Order $order The order to calculate the volume of
+     * @return int The total volume of the order (m^3)
+     */
+    public static function order_volume($order)
+    {
+        $volume = 0;
+
+        if (count($order->get_items()) > 0) {
+            foreach ($order->get_items() as $item) {
+                if ($item['product_id'] > 0) {
+                    $product = $order->get_product_from_item($item);
+                    if (!$product->is_virtual()) {
+                        // Ensure that the volume is in metres
+                        $woo_dim_unit = strtolower(get_option('woocommerce_dimension_unit'));
+                        switch ($woo_dim_unit) {
+                            case 'mm':
+                                $dim_multiplier = 0.001;
+                                break;
+                            case 'cm':
+                                $dim_multiplier = 0.01;
+                                break;
+                            case 'dm':
+                                $dim_multiplier = 0.1;
+                                break;
+                            default:
+                                $dim_multiplier = 1;
+                        }
+                        // Calculate total volume
+                        $volume += pow($dim_multiplier, 3) * $product->get_width()
+                            * $product->get_height() * $product->get_length() * $item['qty'];
+                    }
+                }
+            }
+        }
+
+        return $volume;
+    }
+
+    /**
+     * Get the full-length tracking url of a shipment by providing its service id and tracking code.
+     * Use tracking url provided by pakettikauppa.fi.
+     *
+     * @param int $service_id The id of the service that is used for the shipment
+     * @param int $tracking_code The tracking code of the shipment
+     * @return string The full tracking url for the order
+     */
+    public static function tracking_url($service_id, $tracking_code)
+    {
+        $tracking_url = 'https://www.pakettikauppa.fi/seuranta/?' . $tracking_code;
+        return $tracking_url;
+    }
+
+    /**
+     * Calculate Finnish invoice reference from order ID
+     * http://tarkistusmerkit.teppovuori.fi/tarkmerk.htm#viitenumero
+     *
+     * @param int $id The id of the order to calculate the reference of
+     * @return int The reference number calculated from the id
+     */
+    public static function calculate_reference($id)
+    {
+        $weights = array(7, 3, 1, 7, 3, 1, 7, 3, 1, 7, 3, 1, 7, 3, 1, 7, 3, 1, 7);
+        $base = str_split(strval(($id + 100)));
+        $reversed_base = array_reverse($base);
+        $sum = 0;
+        $reversed_base_length = count($reversed_base);
+
+        for ($i = 0; $i < $reversed_base_length; $i++) {
+            $coefficient = array_shift($weights);
+            $sum += $reversed_base[$i] * $coefficient;
+        }
+
+        $checksum = ($sum % 10 === 0) ? 0 : (10 - $sum % 10);
+
+        $reference = implode('', $base) . $checksum;
+        return $reference;
+    }
+
+    /**
+     * Return the default shipping service if none has been specified
+     *
+     * @TODO: Does this method really need $post or $order, as the default service should
+     * not be order-specific?
+     */
+    public static function get_default_service($post, $order)
+    {
+        // @TODO: Maybe use an option in database so the merchant can set it in settings
+        $service = '2103';
+        return $service;
+    }
+
+    /**
+     * Validate order details in wp-admin. Especially useful, when creating orders in wp-admin,
+     *
+     * @param WC_Order $order The order that needs its info to be validated
+     * @return True, if the details where valid, or false if not
+     */
+    public static function validate_order_shipping_receiver($order)
+    {
+        // Check shipping info first
+        $no_shipping_name = (bool)empty($order->get_formatted_shipping_full_name());
+        $no_shipping_address = (bool)empty($order->get_shipping_address_1()) && empty($order->get_shipping_address_2());
+        $no_shipping_postcode = (bool)empty($order->get_shipping_postcode());
+        $no_shipping_city = (bool)empty($order->get_shipping_city());
+
+        if ($no_shipping_name || $no_shipping_address || $no_shipping_postcode || $no_shipping_city) {
+            return false;
+        }
+        return true;
+    }
+
+    public static function service_has_pickup_points($service_id)
+    {
+        // @TODO: Find out if the Pakettikauppa API can be used to check if the service uses
+        // pickup points instead of hard coding them here.
+        $services_with_pickup_points = array(
+            '2103',
+            '80010',
+            '90010',
+            '90080',
+        );
+
+        if (in_array($service_id, $services_with_pickup_points, true)) {
+            return true;
+        }
+        return false;
+    }
 
 }

--- a/includes/class-wc-pakettikauppa-shipment.php
+++ b/includes/class-wc-pakettikauppa-shipment.php
@@ -229,7 +229,7 @@ class WC_Pakettikauppa_Shipment
 
         // @TODO: File bug upstream about result being string instead of object by default
         $transient_name = 'wc_pakettikauppa_shipping_methods';
-        $transent_time = 86400; // 24 hours
+        $transient_time = 86400; // 24 hours
         $all_shipping_methods = get_transient($transient_name);
 
         if (false === $all_shipping_methods) {

--- a/includes/class-wc-pakettikauppa-shipping-method.php
+++ b/includes/class-wc-pakettikauppa-shipping-method.php
@@ -282,7 +282,8 @@ function wc_pakettikauppa_shipping_method_init()
              * @param $shippingCost
              * @return array
              */
-            private function calculate_shipping_tax($shippingCost) {
+            private function calculate_shipping_tax($shippingCost)
+            {
                 $taxes = array();
 
                 $taxesTotal = 0;
@@ -292,34 +293,35 @@ function wc_pakettikauppa_shipping_method_init()
 
                 $costs = array();
 
-                foreach($cart as $item) {
+                foreach ($cart as $item) {
                     $costs[$item['key']] = $shippingCost * $item['line_total'] / $cart_total;
                 }
 
                 // If we have an array of costs we can look up each items tax class and add tax accordingly.
-                if ( is_array( $costs ) ) {
+                if (is_array($costs)) {
                     $cart = WC()->cart->get_cart();
 
-                    foreach ( $costs as $cost_key => $amount ) {
-                        if ( ! isset( $cart[ $cost_key ] ) ) {
+                    foreach ($costs as $cost_key => $amount) {
+                        if (!isset($cart[$cost_key])) {
                             continue;
                         }
 
-                        $taxObj = WC_Tax::get_shipping_tax_rates( $cart[ $cost_key ]['data']->get_tax_class() );
-                        $item_taxes = WC_Tax::calc_shipping_tax( $amount,  $taxObj );
+                        $taxObj = WC_Tax::get_shipping_tax_rates($cart[$cost_key]['data']->get_tax_class());
+                        $item_taxes = WC_Tax::calc_shipping_tax($amount, $taxObj);
 
                         // Sum the item taxes.
-                        foreach ( array_keys( $taxes + $item_taxes ) as $key ) {
-                            $taxes[ $key ] = round(( isset( $item_taxes[ $key ] ) ? $item_taxes[ $key ] : 0 ) + ( isset( $taxes[ $key ] ) ? $taxes[ $key ] : 0), 2);
+                        foreach (array_keys($taxes + $item_taxes) as $key) {
+                            $taxes[$key] = round((isset($item_taxes[$key]) ? $item_taxes[$key] : 0) + (isset($taxes[$key]) ? $taxes[$key] : 0), 2);
                         }
                     }
                 }
 
-                foreach($taxes as $_tax) {
-                    $taxesTotal+=$_tax;
+                foreach ($taxes as $_tax) {
+                    $taxesTotal += $_tax;
                 }
                 return array('total' => $taxesTotal, 'taxes' => $taxes);
             }
+
             /**
              * Called to calculate shipping rates for this method. Rates can be added using the add_rate() method.
              * Return only active shipping methods.

--- a/includes/class-wc-pakettikauppa-shipping-method.php
+++ b/includes/class-wc-pakettikauppa-shipping-method.php
@@ -1,12 +1,12 @@
 <?php
 
 // Prevent direct access to the script
-if ( ! defined( 'ABSPATH' ) ) {
-  exit;
+if (!defined('ABSPATH')) {
+    exit;
 }
 
-require_once plugin_dir_path( __FILE__ ) . '/class-wc-pakettikauppa.php';
-require_once plugin_dir_path(__FILE__ ) . '/class-wc-pakettikauppa-shipment.php';
+require_once plugin_dir_path(__FILE__) . '/class-wc-pakettikauppa.php';
+require_once plugin_dir_path(__FILE__) . '/class-wc-pakettikauppa-shipment.php';
 
 /**
  * Pakettikauppa_Shipping_Method Class
@@ -17,295 +17,319 @@ require_once plugin_dir_path(__FILE__ ) . '/class-wc-pakettikauppa-shipment.php'
  * @package  woocommerce-pakettikauppa
  * @author Seravo
  */
-function wc_pakettikauppa_shipping_method_init() {
+function wc_pakettikauppa_shipping_method_init()
+{
 
-  if ( ! class_exists( 'WC_Pakettikauppa_Shipping_Method' ) ) {
+    if (!class_exists('WC_Pakettikauppa_Shipping_Method')) {
 
-    class WC_Pakettikauppa_Shipping_Method extends WC_Shipping_Method {
-      /**
-       * Required to access pakettikauppa client
-       */
-      private $wc_pakettikauppa_shipment = null;
+        class WC_Pakettikauppa_Shipping_Method extends WC_Shipping_Method
+        {
+            /**
+             * Required to access pakettikauppa client
+             */
+            private $wc_pakettikauppa_shipment = null;
 
-      /**
-       * Default shipping fee.
-       *
-       * @var int
-       */
-      public $fee = 5.95;
+            /**
+             * Default shipping fee.
+             *
+             * @var int
+             */
+            public $fee = 5.95;
 
-      /**
-       * Constructor for Pakettikauppa shipping class
-       *
-       * @access public
-       * @return void
-       */
-      public function __construct( $instance_id = 0 ) {
-        $this->id                 = 'WC_Pakettikauppa_Shipping_Method'; // ID for your shipping method. Should be unique.
-        $this->instance_id        = absint( $instance_id );
+            /**
+             * Constructor for Pakettikauppa shipping class
+             *
+             * @access public
+             * @return void
+             */
+            public function __construct($instance_id = 0)
+            {
+                $this->id = 'WC_Pakettikauppa_Shipping_Method'; // ID for your shipping method. Should be unique.
+                $this->instance_id = absint($instance_id);
 
-        $this->method_title       = 'Pakettikauppa'; // Title shown in admin
-        $this->method_description = __( 'All shipping methods with one contract. For more information visit <a href="https://www.pakettikauppa.fi/">Pakettikauppa</a>.', 'wc-pakettikauppa' ); // Description shown in admin
+                $this->method_title = 'Pakettikauppa'; // Title shown in admin
+                $this->method_description = __('All shipping methods with one contract. For more information visit <a href="https://www.pakettikauppa.fi/">Pakettikauppa</a>.', 'wc-pakettikauppa'); // Description shown in admin
 
-        $this->enabled = 'yes';
-        $this->title   = 'Pakettikauppa';
+                $this->enabled = 'yes';
+                $this->title = 'Pakettikauppa';
 
-        $this->init();
-      }
-
-      public function validate_pkprice_field( $key, $value ) {
-        foreach( $value as $service_code => $service_settings ) {
-          $service_settings['price'] = wc_format_decimal( trim( stripslashes( $service_settings['price'] ) ) );
-          $service_settings['price_free'] = wc_format_decimal( trim( stripslashes( $service_settings['price'] ) ) );
-        }
-        $values = json_encode( $value );
-
-        return $values;
-      }
-
-      public function generate_pkprice_html( $key, $value ) {
-        $field_key = $this->get_field_key( $key );
-
-        if ( $this->get_option( $key ) !== '' ) {
-
-          $values = $this->get_option( $key );
-          if ( is_string( $values ) ) {
-            $values = json_decode( $this->get_option( $key ), true );
-          }
-        } else {
-          $values = array();
-        }
-
-        ob_start();
-        ?>
-
-        <tr valign="top">
-          <?php if ( isset( $value['title'] ) ) : ?>
-            <th colspan="2"><label><?php esc_html( $value['title'] ); ?></label></th>
-          <?php endif; ?>
-        </tr>
-        <tr>
-          <td colspan="2">
-            <table>
-              <thead>
-                <tr>
-                 <th><?php esc_attr_e( 'Service', 'wc-pakettikauppa' ); ?></th>
-                 <th style="width: 60px;"><?php esc_attr_e( 'Active', 'wc-pakettikauppa' ); ?></th>
-                 <th style="text-align: center;"><?php esc_attr_e( 'Price', 'wc-pakettikauppa' ); ?></th>
-                 <th style="text-align: center;"><?php esc_attr_e( 'Free shipping tier', 'wc-pakettikauppa' ); ?></th>
-                </tr>
-              </thead>
-              <tbody>
-              <?php if ( isset( $value['options'] ) ) : ?>
-                <?php foreach( $value['options'] as $service_code => $service_name ) : ?>
-                  <?php if ( ! isset( $values[$service_code] ) ) : ?>
-                    <?php $values[$service_code]['active']  = false; ?>
-                    <?php $values[$service_code]['price']  = $this->fee; ?>
-                    <?php $values[$service_code]['price_free']  = '0'; ?>
-                  <?php endif; ?>
-
-                  <tr valign="top">
-                    <th scope="row" class="titledesc">
-                      <label><?php echo esc_html( $service_name ); ?></label>
-                    </th>
-                    <td>
-                      <input type="hidden" name="<?php echo esc_html( $field_key ) . '[' . esc_html( $service_code ) . '][active]'; ?>" value="no">
-                      <input type="checkbox" name="<?php echo esc_html( $field_key ) . '[' . esc_html( $service_code ) . '][active]'; ?>" value="yes" <?php echo $values[$service_code]['active'] === 'yes' ? 'checked': ''; ?>>
-                    </td>
-                    <td>
-                      <input type="number" name="<?php echo esc_html( $field_key ) . '[' . esc_html( $service_code ) . '][price]'; ?>" step="0.01" value="<?php echo esc_html( $values[$service_code]['price']); ?>">
-                    </td>
-                    <td>
-                      <input type="number" name="<?php echo esc_html( $field_key ) . '[' . esc_html( $service_code ) . '][price_free]'; ?>" step="0.01" value="<?php echo esc_html( $values[$service_code]['price_free']); ?>">
-                    </td>
-                  </tr>
-                <?php endforeach; ?>
-              <?php endif; ?>
-
-            </tbody>
-          </table>
-          </td>
-        </tr>
-
-        <?php
-
-        $html = ob_get_contents();
-        ob_end_clean();
-
-        return $html;
-      }
-
-      /**
-       * Initialize Pakettikauppa shipping
-       */
-      public function init() {
-        // Make Pakettikauppa API accessible via WC_Pakettikauppa_Shipment
-        $this->wc_pakettikauppa_shipment = new WC_Pakettikauppa_Shipment();
-        $this->wc_pakettikauppa_shipment->load();
-
-        // Save settings in admin if you have any defined
-        add_action( 'woocommerce_update_options_shipping_' . $this->id, array( $this, 'process_admin_options' ) );
-
-        // Load the settings.
-        $this->init_form_fields();
-        $this->init_settings();
-
-      }
-
-      /**
-       * Init form fields.
-       */
-      public function init_form_fields() {
-        $this->form_fields = array(
-          'mode'                       => array(
-            'title'   => __( 'Mode', 'wc-pakettikauppa' ),
-            'type'    => 'select',
-            'default' => 'test',
-            'options' => array(
-              'test'       => __( 'Test environment', 'wc-pakettikauppa' ),
-              'production' => __( 'Production environment', 'wc-pakettikauppa' ),
-            ),
-          ),
-
-          'account_number'             => array(
-            'title'    => __( 'API key', 'wc-pakettikauppa' ),
-            'desc'     => __( 'API key provided by Pakettikauppa', 'wc-pakettikauppa' ),
-            'type'     => 'text',
-            'default'  => '',
-            'desc_tip' => true,
-          ),
-
-          'secret_key'                 => array(
-            'title'    => __( 'API secret', 'wc-pakettikauppa' ),
-            'desc'     => __( 'API Secret provided by Pakettikauppa', 'wc-pakettikauppa' ),
-            'type'     => 'text',
-            'default'  => '',
-            'desc_tip' => true,
-          ),
-
-          /* Start new section */
-          array(
-            'title' => __( 'Shipping settings', 'wc-pakettikauppa' ),
-            'type'  => 'title',
-          ),
-
-          'active_shipping_options'    => array(
-            'type'        => 'pkprice',
-            'options' => $this->wc_pakettikauppa_shipment->services(),
-          ),
-
-          'add_tracking_to_email'      => array(
-            'title'   => __( 'Add tracking link to the order completed email', 'wc-pakettikauppa' ),
-            'type'    => 'checkbox',
-            'default' => 'no',
-          ),
-
-          'pickup_points_search_limit' => array(
-            'title'       => __( 'Pickup point search limit', 'wc-pakettikauppa' ),
-            'type'        => 'number',
-            'default'     => 5,
-            'description' => __( 'Limit the amount of nearest pickup points shown.', 'wc-pakettikauppa' ),
-            'desc_tip'    => true,
-          ),
-
-          /* Start new section */
-          array(
-            'title' => __( 'Store owner information', 'wc-pakettikauppa' ),
-            'type'  => 'title',
-          ),
-
-          'sender_name'                => array(
-            'title'   => __( 'Sender name', 'wc-pakettikauppa' ),
-            'type'    => 'text',
-            'default' => '',
-          ),
-
-          'sender_address'             => array(
-            'title'   => __( 'Sender address', 'wc-pakettikauppa' ),
-            'type'    => 'text',
-            'default' => '',
-          ),
-
-          'sender_postal_code'         => array(
-            'title'   => __( 'Sender postal code', 'wc-pakettikauppa' ),
-            'type'    => 'text',
-            'default' => '',
-          ),
-
-          'sender_city'                => array(
-            'title'   => __( 'Sender city', 'wc-pakettikauppa' ),
-            'type'    => 'text',
-            'default' => '',
-          ),
-
-          'cod_iban'                   => array(
-            'title'   => __( 'Bank account number for Cash on Delivery (IBAN)', 'wc-pakettikauppa' ),
-            'type'    => 'text',
-            'default' => '',
-          ),
-
-          'cod_bic'                    => array(
-            'title'   => __( 'BIC code for Cash on Delivery', 'wc-pakettikauppa' ),
-            'type'    => 'text',
-            'default' => '',
-          ),
-
-            'info_code' => array(
-                    'title' => __('Info-code for shipments'),
-                'type' => 'text',
-                'default' => '',
-            ),
-        );
-      }
-
-      /**
-       * Called to calculate shipping rates for this method. Rates can be added using the add_rate() method.
-       * Return only active shipping methods.
-       *
-       * @uses WC_Shipping_Method::add_rate()
-       *
-       * @param array $package Shipping package.
-       */
-      public function calculate_shipping( $package = array() ) {
-        global $woocommerce;
-
-        $cart_total = $woocommerce->cart->cart_contents_total;
-
-        $shipping_settings = json_decode( $this->get_option( 'active_shipping_options' ), true );
-
-        foreach( $shipping_settings as $service_code => $service_settings ) {
-
-          if ( $service_settings['active'] === 'yes' ) {
-
-            $shipping_cost = $service_settings['price'];
-
-            if ( $service_settings['price_free'] < $cart_total && $service_settings['price_free'] > 0 ) {
-              $shipping_cost = 0;
+                $this->init();
             }
 
-            $this->add_rate(
-              array(
-                'id'    => $this->id .':'. $service_code,
-                'label' => $this->wc_pakettikauppa_shipment->service_title( $service_code ),
-                'cost'  => (string) $shipping_cost
-              )
-            );
-          }
+            public function validate_pkprice_field($key, $value)
+            {
+                foreach ($value as $service_code => $service_settings) {
+                    $service_settings['price'] = wc_format_decimal(trim(stripslashes($service_settings['price'])));
+                    $service_settings['price_free'] = wc_format_decimal(trim(stripslashes($service_settings['price'])));
+                }
+                $values = json_encode($value);
+
+                return $values;
+            }
+
+            public function generate_pkprice_html($key, $value)
+            {
+                $field_key = $this->get_field_key($key);
+
+                if ($this->get_option($key) !== '') {
+
+                    $values = $this->get_option($key);
+                    if (is_string($values)) {
+                        $values = json_decode($this->get_option($key), true);
+                    }
+                } else {
+                    $values = array();
+                }
+
+                ob_start();
+                ?>
+
+                <tr valign="top">
+                    <?php if (isset($value['title'])) : ?>
+                        <th colspan="2"><label><?php esc_html($value['title']); ?></label></th>
+                    <?php endif; ?>
+                </tr>
+                <tr>
+                    <td colspan="2">
+                        <table>
+                            <thead>
+                            <tr>
+                                <th><?php esc_attr_e('Service', 'wc-pakettikauppa'); ?></th>
+                                <th style="width: 60px;"><?php esc_attr_e('Active', 'wc-pakettikauppa'); ?></th>
+                                <th style="text-align: center;"><?php esc_attr_e('Price', 'wc-pakettikauppa'); ?></th>
+                                <th style="text-align: center;"><?php esc_attr_e('Free shipping tier', 'wc-pakettikauppa'); ?></th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            <?php if (isset($value['options'])) : ?>
+                                <?php foreach ($value['options'] as $service_code => $service_name) : ?>
+                                    <?php if (!isset($values[$service_code])) : ?>
+                                        <?php $values[$service_code]['active'] = false; ?>
+                                        <?php $values[$service_code]['price'] = $this->fee; ?>
+                                        <?php $values[$service_code]['price_free'] = '0'; ?>
+                                    <?php endif; ?>
+
+                                    <tr valign="top">
+                                        <th scope="row" class="titledesc">
+                                            <label><?php echo esc_html($service_name); ?></label>
+                                        </th>
+                                        <td>
+                                            <input type="hidden"
+                                                   name="<?php echo esc_html($field_key) . '[' . esc_html($service_code) . '][active]'; ?>"
+                                                   value="no">
+                                            <input type="checkbox"
+                                                   name="<?php echo esc_html($field_key) . '[' . esc_html($service_code) . '][active]'; ?>"
+                                                   value="yes" <?php echo $values[$service_code]['active'] === 'yes' ? 'checked' : ''; ?>>
+                                        </td>
+                                        <td>
+                                            <input type="number"
+                                                   name="<?php echo esc_html($field_key) . '[' . esc_html($service_code) . '][price]'; ?>"
+                                                   step="0.01"
+                                                   value="<?php echo esc_html($values[$service_code]['price']); ?>">
+                                        </td>
+                                        <td>
+                                            <input type="number"
+                                                   name="<?php echo esc_html($field_key) . '[' . esc_html($service_code) . '][price_free]'; ?>"
+                                                   step="0.01"
+                                                   value="<?php echo esc_html($values[$service_code]['price_free']); ?>">
+                                        </td>
+                                    </tr>
+                                <?php endforeach; ?>
+                            <?php endif; ?>
+
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+
+                <?php
+
+                $html = ob_get_contents();
+                ob_end_clean();
+
+                return $html;
+            }
+
+            /**
+             * Initialize Pakettikauppa shipping
+             */
+            public function init()
+            {
+                // Make Pakettikauppa API accessible via WC_Pakettikauppa_Shipment
+                $this->wc_pakettikauppa_shipment = new WC_Pakettikauppa_Shipment();
+                $this->wc_pakettikauppa_shipment->load();
+
+                // Save settings in admin if you have any defined
+                add_action('woocommerce_update_options_shipping_' . $this->id, array($this, 'process_admin_options'));
+
+                // Load the settings.
+                $this->init_form_fields();
+                $this->init_settings();
+
+            }
+
+            /**
+             * Init form fields.
+             */
+            public function init_form_fields()
+            {
+                $this->form_fields = array(
+                    'mode' => array(
+                        'title' => __('Mode', 'wc-pakettikauppa'),
+                        'type' => 'select',
+                        'default' => 'test',
+                        'options' => array(
+                            'test' => __('Test environment', 'wc-pakettikauppa'),
+                            'production' => __('Production environment', 'wc-pakettikauppa'),
+                        ),
+                    ),
+
+                    'account_number' => array(
+                        'title' => __('API key', 'wc-pakettikauppa'),
+                        'desc' => __('API key provided by Pakettikauppa', 'wc-pakettikauppa'),
+                        'type' => 'text',
+                        'default' => '',
+                        'desc_tip' => true,
+                    ),
+
+                    'secret_key' => array(
+                        'title' => __('API secret', 'wc-pakettikauppa'),
+                        'desc' => __('API Secret provided by Pakettikauppa', 'wc-pakettikauppa'),
+                        'type' => 'text',
+                        'default' => '',
+                        'desc_tip' => true,
+                    ),
+
+                    /* Start new section */
+                    array(
+                        'title' => __('Shipping settings', 'wc-pakettikauppa'),
+                        'type' => 'title',
+                    ),
+
+                    'active_shipping_options' => array(
+                        'type' => 'pkprice',
+                        'options' => $this->wc_pakettikauppa_shipment->services(),
+                    ),
+
+                    'add_tracking_to_email' => array(
+                        'title' => __('Add tracking link to the order completed email', 'wc-pakettikauppa'),
+                        'type' => 'checkbox',
+                        'default' => 'no',
+                    ),
+
+                    'pickup_points_search_limit' => array(
+                        'title' => __('Pickup point search limit', 'wc-pakettikauppa'),
+                        'type' => 'number',
+                        'default' => 5,
+                        'description' => __('Limit the amount of nearest pickup points shown.', 'wc-pakettikauppa'),
+                        'desc_tip' => true,
+                    ),
+
+                    /* Start new section */
+                    array(
+                        'title' => __('Store owner information', 'wc-pakettikauppa'),
+                        'type' => 'title',
+                    ),
+
+                    'sender_name' => array(
+                        'title' => __('Sender name', 'wc-pakettikauppa'),
+                        'type' => 'text',
+                        'default' => '',
+                    ),
+
+                    'sender_address' => array(
+                        'title' => __('Sender address', 'wc-pakettikauppa'),
+                        'type' => 'text',
+                        'default' => '',
+                    ),
+
+                    'sender_postal_code' => array(
+                        'title' => __('Sender postal code', 'wc-pakettikauppa'),
+                        'type' => 'text',
+                        'default' => '',
+                    ),
+
+                    'sender_city' => array(
+                        'title' => __('Sender city', 'wc-pakettikauppa'),
+                        'type' => 'text',
+                        'default' => '',
+                    ),
+
+                    'cod_iban' => array(
+                        'title' => __('Bank account number for Cash on Delivery (IBAN)', 'wc-pakettikauppa'),
+                        'type' => 'text',
+                        'default' => '',
+                    ),
+
+                    'cod_bic' => array(
+                        'title' => __('BIC code for Cash on Delivery', 'wc-pakettikauppa'),
+                        'type' => 'text',
+                        'default' => '',
+                    ),
+
+                    'info_code' => array(
+                        'title' => __('Info-code for shipments'),
+                        'type' => 'text',
+                        'default' => '',
+                    ),
+                );
+            }
+
+            /**
+             * Called to calculate shipping rates for this method. Rates can be added using the add_rate() method.
+             * Return only active shipping methods.
+             *
+             * @uses WC_Shipping_Method::add_rate()
+             *
+             * @param array $package Shipping package.
+             */
+            public function calculate_shipping($package = array())
+            {
+                global $woocommerce;
+
+                $cart_total = $woocommerce->cart->cart_contents_total;
+                /*
+                        echo "<pre>";
+
+                        var_dump(WC()->cart);
+                          echo "</pre>";
+                */
+                $shipping_settings = json_decode($this->get_option('active_shipping_options'), true);
+
+                foreach ($shipping_settings as $service_code => $service_settings) {
+
+                    if ($service_settings['active'] === 'yes') {
+
+                        $shipping_cost = $service_settings['price'];
+
+                        if ($service_settings['price_free'] < $cart_total && $service_settings['price_free'] > 0) {
+                            $shipping_cost = 0;
+                        }
+
+                        $this->add_rate(
+                            array(
+                                'id' => $this->id . ':' . $service_code,
+                                'label' => $this->wc_pakettikauppa_shipment->service_title($service_code),
+                                'cost' => (string)$shipping_cost
+                            )
+                        );
+                    }
+                }
+
+            }
+
         }
-
-      }
-
     }
-  }
 }
 
-add_action( 'woocommerce_shipping_init', 'wc_pakettikauppa_shipping_method_init' );
+add_action('woocommerce_shipping_init', 'wc_pakettikauppa_shipping_method_init');
 
-function add_wc_pakettikauppa_shipping_method( $methods ) {
+function add_wc_pakettikauppa_shipping_method($methods)
+{
 
-  $methods[] = 'WC_Pakettikauppa_Shipping_Method';
-  return $methods;
+    $methods[] = 'WC_Pakettikauppa_Shipping_Method';
+    return $methods;
 
 }
 
-add_filter( 'woocommerce_shipping_methods', 'add_wc_pakettikauppa_shipping_method' );
+add_filter('woocommerce_shipping_methods', 'add_wc_pakettikauppa_shipping_method');

--- a/includes/class-wc-pakettikauppa-shipping-method.php
+++ b/includes/class-wc-pakettikauppa-shipping-method.php
@@ -250,6 +250,11 @@ function wc_pakettikauppa_shipping_method_init() {
             'default' => '',
           ),
 
+            'info_code' => array(
+                    'title' => __('Info-code for shipments'),
+                'type' => 'text',
+                'default' => '',
+            ),
         );
       }
 

--- a/includes/class-wc-pakettikauppa.php
+++ b/includes/class-wc-pakettikauppa.php
@@ -1,8 +1,8 @@
 <?php
 
 // Prevent direct access to this script
-if ( ! defined( 'ABSPATH' ) ) {
-  exit;
+if (!defined('ABSPATH')) {
+    exit;
 }
 
 require_once WC_PAKETTIKAUPPA_DIR . 'vendor/autoload.php';
@@ -17,178 +17,188 @@ require_once WC_PAKETTIKAUPPA_DIR . 'includes/class-wc-pakettikauppa-shipment.ph
  * @package  woocommerce-pakettikauppa
  * @author Seravo
  */
-class WC_Pakettikauppa {
-  private $wc_pakettikauppa_shipment = null;
-  private $errors                    = array();
+class WC_Pakettikauppa
+{
+    private $wc_pakettikauppa_shipment = null;
+    private $errors = array();
 
-  public function __construct() {
-    $this->id = 'wc_pakettikauppa';
-  }
-
-  public function load() {
-    add_action( 'enqueue_scripts', array( $this, 'enqueue_scripts' ) );
-    add_action( 'woocommerce_review_order_after_shipping', array( $this, 'pickup_point_field_html' ) );
-    add_action( 'woocommerce_order_details_after_order_table', array( $this, 'display_order_data' ) );
-    add_action( 'woocommerce_checkout_update_order_meta', array( $this, 'update_order_meta_pickup_point_field' ) );
-    add_action('woocommerce_checkout_process', array( $this, 'validate_checkout_pickup_point' ) );
-
-    try {
-      $this->wc_pakettikauppa_shipment = new WC_Pakettikauppa_Shipment();
-      $this->wc_pakettikauppa_shipment->load();
-
-    } catch ( Exception $e ) {
-      $this->add_error( $e->getMessage() );
-      $this->display_error();
-    }
-  }
-
-  /**
-   * Add an error with a specified error message.
-   *
-   * @param string $message A message containing details about the error.
-   */
-  public function add_error( $message ) {
-    if ( ! empty( $message ) ) {
-      array_push( $this->errors, $message );
-      error_log( $message );
-    }
-  }
-
-  /**
-   * Display error in woocommerce
-   */
-  public function display_error() {
-    wc_add_notice( __( 'An error occured. Please try again later.', 'wc-pakettikauppa' ), 'error' );
-  }
-
-  /**
-   * Enqueue frontend-specific styles and scripts.
-   */
-  public function enqueue_scripts() {
-    wp_enqueue_style( 'wc_pakettikauppa', plugin_dir_url( __FILE__ ) . '../assets/css/wc-pakettikauppa.css' );
-    wp_enqueue_script( 'wc_pakettikauppa_js', plugin_dir_url( __FILE__ ) . '../assets/js/wc-pakettikauppa.js', array( 'jquery' ) );
-  }
-
-  /**
-   * Update the order meta with pakettikauppa_pickup_point field value
-   * Example value from checkout page: "DB Schenker: R-KIOSKI TRE AMURI (#6681)"
-   *
-   * @param int $order_id The id of the order to update
-   */
-  public function update_order_meta_pickup_point_field( $order_id ) {
-    if ( ! empty( $_POST['pakettikauppa_pickup_point'] ) ) {
-      update_post_meta( $order_id, '_pakettikauppa_pickup_point', sanitize_text_field( $_POST['pakettikauppa_pickup_point'] ) );
-      // Find string like '(#6681)'
-      preg_match( '/\(#[0-9]+\)/', $_POST['pakettikauppa_pickup_point'], $matches);
-      // Cut the number out from a string of the form '(#6681)'
-      $pakettikauppa_pickup_point_id = intval( substr($matches[0], 2, -1) );
-      update_post_meta( $order_id, '_pakettikauppa_pickup_point_id', $pakettikauppa_pickup_point_id );
-    }
-  }
-
-  /*
-   * Customize the layout of the checkout screen so that there is a section
-   * where the pickup point can be defined. Don't use the woocommerce_checkout_fields
-   * filter, it only lists fields without values, and we need to know the postcode.
-   * Also the woocommerce_checkout_fields has separate billing and shipping address
-   * listings, when we want to have only one single pickup point per order.
-   */
-  public function pickup_point_field_html() {
-    $shipping_method_name     = explode(':', WC()->session->get( 'chosen_shipping_methods' )[0])[0];
-    $shipping_method_id       = explode(':', WC()->session->get( 'chosen_shipping_methods' )[0])[1];
-    $shipping_method_provider = $this->wc_pakettikauppa_shipment->service_provider($shipping_method_id);
-
-    // Bail out if the shipping method is not one of the pickup point services
-    if ( ! WC_Pakettikauppa_Shipment::service_has_pickup_points( $shipping_method_id ) ) {
-      return;
+    public function __construct()
+    {
+        $this->id = 'wc_pakettikauppa';
     }
 
-    $pickup_point_data = '';
-    $shipping_postcode = WC()->customer->get_shipping_postcode();
-    $shipping_address  = WC()->customer->get_shipping_address();
-    $shipping_country  = WC()->customer->get_shipping_country();
+    public function load()
+    {
+        add_action('enqueue_scripts', array($this, 'enqueue_scripts'));
+        add_action('woocommerce_review_order_after_shipping', array($this, 'pickup_point_field_html'));
+        add_action('woocommerce_order_details_after_order_table', array($this, 'display_order_data'));
+        add_action('woocommerce_checkout_update_order_meta', array($this, 'update_order_meta_pickup_point_field'));
+        add_action('woocommerce_checkout_process', array($this, 'validate_checkout_pickup_point'));
 
-    if ( empty( $shipping_country ) ) {
-      $shipping_country = 'FI';
+        try {
+            $this->wc_pakettikauppa_shipment = new WC_Pakettikauppa_Shipment();
+            $this->wc_pakettikauppa_shipment->load();
+
+        } catch (Exception $e) {
+            $this->add_error($e->getMessage());
+            $this->display_error();
+        }
     }
 
-    try {
-      $pickup_point_data = $this->wc_pakettikauppa_shipment->get_pickup_points( $shipping_postcode, $shipping_address, $shipping_country, $shipping_method_provider );
-
-    } catch ( Exception $e ) {
-      $this->add_error( $e->getMessage() );
-      $this->display_error();
-      return;
+    /**
+     * Add an error with a specified error message.
+     *
+     * @param string $message A message containing details about the error.
+     */
+    public function add_error($message)
+    {
+        if (!empty($message)) {
+            array_push($this->errors, $message);
+            error_log($message);
+        }
     }
 
-    $pickup_points = json_decode( $pickup_point_data );
-    $options_array = array( '' => '- ' . __('Select a pickup point', 'wc-pakettikauppa') . ' -' );
-
-    foreach ( $pickup_points as $key => $value ) {
-      $pickup_point_key                   = $value->provider . ': ' . $value->name . ' (#' . $value->pickup_point_id . ')';
-      $pickup_point_value                 = $value->provider . ': ' . $value->name . ' (' . $value->street_address . ')';
-      $options_array[ $pickup_point_key ] = $pickup_point_value;
+    /**
+     * Display error in woocommerce
+     */
+    public function display_error()
+    {
+        wc_add_notice(__('An error occured. Please try again later.', 'wc-pakettikauppa'), 'error');
     }
 
-    echo '
+    /**
+     * Enqueue frontend-specific styles and scripts.
+     */
+    public function enqueue_scripts()
+    {
+        wp_enqueue_style('wc_pakettikauppa', plugin_dir_url(__FILE__) . '../assets/css/wc-pakettikauppa.css');
+        wp_enqueue_script('wc_pakettikauppa_js', plugin_dir_url(__FILE__) . '../assets/js/wc-pakettikauppa.js', array('jquery'));
+    }
+
+    /**
+     * Update the order meta with pakettikauppa_pickup_point field value
+     * Example value from checkout page: "DB Schenker: R-KIOSKI TRE AMURI (#6681)"
+     *
+     * @param int $order_id The id of the order to update
+     */
+    public function update_order_meta_pickup_point_field($order_id)
+    {
+        if (!empty($_POST['pakettikauppa_pickup_point'])) {
+            update_post_meta($order_id, '_pakettikauppa_pickup_point', sanitize_text_field($_POST['pakettikauppa_pickup_point']));
+            // Find string like '(#6681)'
+            preg_match('/\(#[0-9]+\)/', $_POST['pakettikauppa_pickup_point'], $matches);
+            // Cut the number out from a string of the form '(#6681)'
+            $pakettikauppa_pickup_point_id = intval(substr($matches[0], 2, -1));
+            update_post_meta($order_id, '_pakettikauppa_pickup_point_id', $pakettikauppa_pickup_point_id);
+        }
+    }
+
+    /*
+     * Customize the layout of the checkout screen so that there is a section
+     * where the pickup point can be defined. Don't use the woocommerce_checkout_fields
+     * filter, it only lists fields without values, and we need to know the postcode.
+     * Also the woocommerce_checkout_fields has separate billing and shipping address
+     * listings, when we want to have only one single pickup point per order.
+     */
+    public function pickup_point_field_html()
+    {
+        $shipping_method_name = explode(':', WC()->session->get('chosen_shipping_methods')[0])[0];
+        $shipping_method_id = explode(':', WC()->session->get('chosen_shipping_methods')[0])[1];
+        $shipping_method_provider = $this->wc_pakettikauppa_shipment->service_provider($shipping_method_id);
+
+        // Bail out if the shipping method is not one of the pickup point services
+        if (!WC_Pakettikauppa_Shipment::service_has_pickup_points($shipping_method_id)) {
+            return;
+        }
+
+        $pickup_point_data = '';
+        $shipping_postcode = WC()->customer->get_shipping_postcode();
+        $shipping_address = WC()->customer->get_shipping_address();
+        $shipping_country = WC()->customer->get_shipping_country();
+
+        if (empty($shipping_country)) {
+            $shipping_country = 'FI';
+        }
+
+        try {
+            $pickup_point_data = $this->wc_pakettikauppa_shipment->get_pickup_points($shipping_postcode, $shipping_address, $shipping_country, $shipping_method_provider);
+
+        } catch (Exception $e) {
+            $this->add_error($e->getMessage());
+            $this->display_error();
+            return;
+        }
+
+        $pickup_points = json_decode($pickup_point_data);
+        $options_array = array('' => '- ' . __('Select a pickup point', 'wc-pakettikauppa') . ' -');
+
+        foreach ($pickup_points as $key => $value) {
+            $pickup_point_key = $value->provider . ': ' . $value->name . ' (#' . $value->pickup_point_id . ')';
+            $pickup_point_value = $value->provider . ': ' . $value->name . ' (' . $value->street_address . ')';
+            $options_array[$pickup_point_key] = $pickup_point_value;
+        }
+
+        echo '
     <tr class="shipping-pickup-point">
       <th>' . esc_attr__('Pickup point', 'wc-pakettikauppa') . '</th>
       <td data-title="' . esc_attr__('Pickup point', 'wc-pakettikauppa') . '">';
 
-    echo '<p>';
-      // Return if the customer has not yet chosen a postcode
-    if ( empty( $shipping_postcode ) ) {
-      esc_attr_e( 'Insert your shipping details to view nearby pickup points', 'wc-pakettikauppa' );
-      return;
+        echo '<p>';
+        // Return if the customer has not yet chosen a postcode
+        if (empty($shipping_postcode)) {
+            esc_attr_e('Insert your shipping details to view nearby pickup points', 'wc-pakettikauppa');
+            return;
+        }
+        printf(
+        /* translators: %s: Postcode */
+            esc_html__('Choose one of the pickup points close to your postcode %s below:', 'wc-pakettikauppa'),
+            '<span class="shipping_postcode_for_pickup">' . esc_attr($shipping_postcode) . '</span>'
+        );
+        echo '</p>';
+
+        woocommerce_form_field(
+            'pakettikauppa_pickup_point', array(
+            'clear' => true,
+            'type' => 'select',
+            'custom_attributes' => array('style' => 'max-width:18em;'),
+            'options' => $options_array,
+        ),
+            null
+        );
+
+        echo '</div>';
+
     }
-    printf(
-      /* translators: %s: Postcode */
-      esc_html__( 'Choose one of the pickup points close to your postcode %s below:', 'wc-pakettikauppa' ),
-      '<span class="shipping_postcode_for_pickup">' . esc_attr( $shipping_postcode ) . '</span>'
-    );
-    echo '</p>';
 
-    woocommerce_form_field(
-      'pakettikauppa_pickup_point', array(
-        'clear'             => true,
-        'type'              => 'select',
-        'custom_attributes' => array( 'style' => 'max-width:18em;' ),
-        'options'           => $options_array,
-      ),
-      null
-    );
+    /**
+     * Display pickup point to customer after order.
+     *
+     * @param WC_Order $order the order that was placed
+     */
+    public function display_order_data($order)
+    {
+        $pickup_point = $order->get_meta('_pakettikauppa_pickup_point');
 
-    echo '</div>';
-
-  }
-
-  /**
-   * Display pickup point to customer after order.
-   *
-   * @param WC_Order $order the order that was placed
-   */
-  public function display_order_data( $order ) {
-    $pickup_point = $order->get_meta('_pakettikauppa_pickup_point');
-
-    if ( ! empty( $pickup_point ) ) {
-      echo '
-      <h2>' . esc_attr__('Pickup point', 'wc-pakettikauppa' ) . '</h2>
-      <p>' . esc_attr( $pickup_point ) . '</p>';
+        if (!empty($pickup_point)) {
+            echo '
+      <h2>' . esc_attr__('Pickup point', 'wc-pakettikauppa') . '</h2>
+      <p>' . esc_attr($pickup_point) . '</p>';
+        }
     }
-  }
 
-  public function validate_checkout_pickup_point() {
-    $shipping_method_id = explode(':', WC()->session->get( 'chosen_shipping_methods' )[0])[1];
-    // Check if the service has a pickup point
-    try {
-      if ( $this->wc_pakettikauppa_shipment->service_has_pickup_points( $shipping_method_id ) && empty( $_POST['pakettikauppa_pickup_point'] ) ) {
-        wc_add_notice( __( 'Please choose a pickup point.', 'wc-pakettikauppa' ), 'error' );
-      }
-    } catch ( Exception $e ) {
-      $this->add_error( $e->getMessage() );
-      $this->display_error();
-      return;
+    public function validate_checkout_pickup_point()
+    {
+        $shipping_method_id = explode(':', WC()->session->get('chosen_shipping_methods')[0])[1];
+        // Check if the service has a pickup point
+        try {
+            if ($this->wc_pakettikauppa_shipment->service_has_pickup_points($shipping_method_id) && empty($_POST['pakettikauppa_pickup_point'])) {
+                wc_add_notice(__('Please choose a pickup point.', 'wc-pakettikauppa'), 'error');
+            }
+        } catch (Exception $e) {
+            $this->add_error($e->getMessage());
+            $this->display_error();
+            return;
+        }
     }
-  }
 
 }

--- a/includes/class-wc-pakettikauppa.php
+++ b/includes/class-wc-pakettikauppa.php
@@ -138,36 +138,34 @@ class WC_Pakettikauppa
             $options_array[$pickup_point_key] = $pickup_point_value;
         }
 
-        echo '
-    <tr class="shipping-pickup-point">
-      <th>' . esc_attr__('Pickup point', 'wc-pakettikauppa') . '</th>
-      <td data-title="' . esc_attr__('Pickup point', 'wc-pakettikauppa') . '">';
+        echo '<tr class="shipping-pickup-point">';
+        echo '<th>' . esc_attr__('Pickup point', 'wc-pakettikauppa') . '</th>';
+        echo '<td data-title="' . esc_attr__('Pickup point', 'wc-pakettikauppa') . '">';
 
-        echo '<p>';
         // Return if the customer has not yet chosen a postcode
         if (empty($shipping_postcode)) {
+            echo '<p>';
             esc_attr_e('Insert your shipping details to view nearby pickup points', 'wc-pakettikauppa');
-            return;
+            echo '</p>';
+        } else {
+            printf(
+            /* translators: %s: Postcode */
+                esc_html__('Choose one of the pickup points close to your postcode %s below:', 'wc-pakettikauppa'),
+                '<span class="shipping_postcode_for_pickup">' . esc_attr($shipping_postcode) . '</span>'
+            );
+
+            woocommerce_form_field(
+                'pakettikauppa_pickup_point', array(
+                    'clear' => true,
+                    'type' => 'select',
+                    'custom_attributes' => array('style' => 'word-wrap: normal;'),
+                    'options' => $options_array,
+                ),
+                null
+            );
         }
-        printf(
-        /* translators: %s: Postcode */
-            esc_html__('Choose one of the pickup points close to your postcode %s below:', 'wc-pakettikauppa'),
-            '<span class="shipping_postcode_for_pickup">' . esc_attr($shipping_postcode) . '</span>'
-        );
-        echo '</p>';
 
-        woocommerce_form_field(
-            'pakettikauppa_pickup_point', array(
-            'clear' => true,
-            'type' => 'select',
-            'custom_attributes' => array('style' => 'max-width:18em;'),
-            'options' => $options_array,
-        ),
-            null
-        );
-
-        echo '</div>';
-
+        echo '</td></tr>';
     }
 
     /**

--- a/includes/class-wc-pakettikauppa.php
+++ b/includes/class-wc-pakettikauppa.php
@@ -155,7 +155,8 @@ class WC_Pakettikauppa
             );
 
             woocommerce_form_field(
-                'pakettikauppa_pickup_point', array(
+                'pakettikauppa_pickup_point',
+                array(
                     'clear' => true,
                     'type' => 'select',
                     'custom_attributes' => array('style' => 'word-wrap: normal;'),

--- a/readme.txt
+++ b/readme.txt
@@ -15,7 +15,7 @@ This plugin enables WooCommerce orders to ship using pretty much any shipping me
 
 [Pakettikauppa](https://www.pakettikauppa.fi/) is a shipping service provider in Finland. This plugin integrates their service into WooCommerce. To start shipping, all your WooCommerce needs is this plugin and a merchant ID of your account registered with Pakettikauppa.
 
-> *Note!* If you already have shipping contracts with Posti, Matkahuolto or DB Schenker with reduced prices, you can contact the customer support of Pakettikauppa to get those contracts via Pakettikauppa so you can use the WooCommerce Pakettikauppa plugin with your current shipping contracts.
+> *Note!* If you already have shipping contracts with Posti, Matkahuolto, DB Schenker or GLS with reduced prices, you can contact the customer support of Pakettikauppa to get those contracts via Pakettikauppa so you can use the WooCommerce Pakettikauppa plugin with your current shipping contracts.
 
 # Features
 

--- a/vendor/pakettikauppa/api-library/examples/search-pickup-points-text.php
+++ b/vendor/pakettikauppa/api-library/examples/search-pickup-points-text.php
@@ -1,0 +1,14 @@
+<?php
+
+error_reporting(E_ALL|E_STRICT);
+ini_set('display_errors', 1);
+
+require '../vendor/autoload.php';
+
+use Pakettikauppa\Client;
+
+$client = new Client(array('test_mode' => true));
+
+$result = $client->searchPickupPointsByText('Keskustori 1, 33100 Tampere');
+
+var_dump(json_decode($result));

--- a/vendor/pakettikauppa/api-library/src/Pakettikauppa/Shipment.php
+++ b/vendor/pakettikauppa/api-library/src/Pakettikauppa/Shipment.php
@@ -179,11 +179,11 @@ class Shipment
     /**
      * Builds the xml from given data
      *
-     * @return \SimpleXMLElement
+     * @return SimpleXMLElement
      */
     private function toXml()
     {
-        $xml = new \SimpleXMLElement('<eChannel/>');
+        $xml = new SimpleXMLElement('<eChannel/>');
 
         $routing = $xml->addChild('ROUTING');
         $routing->addChild("Routing.Time", time());

--- a/vendor/pakettikauppa/api-library/src/Pakettikauppa/Shipment/Parcel.php
+++ b/vendor/pakettikauppa/api-library/src/Pakettikauppa/Shipment/Parcel.php
@@ -113,7 +113,7 @@ class Parcel
      */
     public function setVolume($volume)
     {
-        $this->volume = $volume;
+        $this->volume = round($volume, 4);
     }
 
     /**

--- a/vendor/pakettikauppa/api-library/src/Pakettikauppa/SimpleXMLElement.php
+++ b/vendor/pakettikauppa/api-library/src/Pakettikauppa/SimpleXMLElement.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Pakettikauppa;
+
+class SimpleXMLElement extends \SimpleXMLElement
+{
+  /**
+   * Escapes input text
+   *
+   * @param string
+   * @param string
+   */
+  public function addChild($key, $value = null, $namespace = null)
+  {
+    if ( $value != null )
+    {
+      $value = htmlspecialchars($value, ENT_XML1);
+    }
+
+    return parent::addChild($key, $value, $namespace);
+  }
+}

--- a/wc-pakettikauppa.php
+++ b/wc-pakettikauppa.php
@@ -26,28 +26,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 // @TODO: Also check for other solutions to refer to plugin_basename and plugin_dir_path in includes/ directory
 define( 'WC_PAKETTIKAUPPA_BASENAME', plugin_basename( __FILE__ ) );
 define( 'WC_PAKETTIKAUPPA_DIR', plugin_dir_path( __FILE__ ) );
-$upload_dir = wp_upload_dir();
-define( 'WC_PAKETTIKAUPPA_PRIVATE_DIR', $upload_dir['basedir'] . '/wc-pakettikauppa' );
-// @TODO: Now the location is unprotected. In future, allow users to customize this
-// location and use techniques like X-Sendfile to limit access to logged in users.
-
-/**
- * Prepare private directory for pakettikauppa documents.
- */
-function wc_pakettikauppa_prepare_directory() {
-  // Create directory for plugin documents if does not yet exist
-  if ( ! file_exists( WC_PAKETTIKAUPPA_PRIVATE_DIR ) ) {
-    @wp_mkdir_p( WC_PAKETTIKAUPPA_PRIVATE_DIR );
-    chmod( WC_PAKETTIKAUPPA_PRIVATE_DIR, 0755 );
-  }
-
-  // Create index.php to disallow directory listing in some incorrectly configured servers
-  $index_file = WC_PAKETTIKAUPPA_PRIVATE_DIR . '/index.php';
-  if ( ! file_exists( $index_file ) ) {
-    touch( $index_file );
-  }
-}
-add_action( 'init', 'wc_pakettikauppa_prepare_directory' );
 
 /**
  * Load plugin textdomain

--- a/wc-pakettikauppa.php
+++ b/wc-pakettikauppa.php
@@ -19,47 +19,47 @@
  */
 
 // Prevent direct access to this script
-if(!defined('ABSPATH')) {
+if ( ! defined ('ABSPATH')) {
     exit;
 }
 
 // @TODO: Also check for other solutions to refer to plugin_basename and plugin_dir_path in includes/ directory
-define('WC_PAKETTIKAUPPA_BASENAME', plugin_basename(__FILE__));
-define('WC_PAKETTIKAUPPA_DIR', plugin_dir_path(__FILE__));
+define ('WC_PAKETTIKAUPPA_BASENAME', plugin_basename (__FILE__));
+define ('WC_PAKETTIKAUPPA_DIR', plugin_dir_path (__FILE__));
 
 /**
  * Load plugin textdomain
  *
  * @return void
  */
-function wc_pakettikauppa_load_textdomain() {
-    load_plugin_textdomain('wc-pakettikauppa', false, dirname(plugin_basename(__FILE__)) . '/languages/');
+function wc_pakettikauppa_load_textdomain () {
+    load_plugin_textdomain ('wc-pakettikauppa', false, dirname (plugin_basename (__FILE__)) . '/languages/');
 }
 
-add_action('plugins_loaded', 'wc_pakettikauppa_load_textdomain');
+add_action ('plugins_loaded', 'wc_pakettikauppa_load_textdomain');
 
-require_once plugin_dir_path(__FILE__) . 'includes/class-wc-pakettikauppa-shipping-method.php';
+require_once plugin_dir_path (__FILE__) . 'includes/class-wc-pakettikauppa-shipping-method.php';
 
 /**
  * Load the WC_Pakettikauppa class when in frontend
  */
-function wc_pakettikauppa_load() {
-    if(!is_admin()) {
-        require_once plugin_dir_path(__FILE__) . 'includes/class-wc-pakettikauppa.php';
+function wc_pakettikauppa_load () {
+    if ( ! is_admin ()) {
+        require_once plugin_dir_path (__FILE__) . 'includes/class-wc-pakettikauppa.php';
         $wc_pakettikauppa = new WC_Pakettikauppa();
-        $wc_pakettikauppa->load();
+        $wc_pakettikauppa->load ();
     }
 }
 
-add_action('init', 'wc_pakettikauppa_load');
+add_action ('init', 'wc_pakettikauppa_load');
 
 /**
  * Load the WC_Pakettikauppa_Admin class in wp-admin
  */
-function wc_pakettikauppa_load_admin() {
-    require_once plugin_dir_path(__FILE__) . 'includes/class-wc-pakettikauppa-admin.php';
+function wc_pakettikauppa_load_admin () {
+    require_once plugin_dir_path (__FILE__) . 'includes/class-wc-pakettikauppa-admin.php';
     $wc_pakettikauppa_admin = new WC_Pakettikauppa_Admin();
-    $wc_pakettikauppa_admin->load();
+    $wc_pakettikauppa_admin->load ();
 }
 
-add_action('admin_init', 'wc_pakettikauppa_load_admin');
+add_action ('admin_init', 'wc_pakettikauppa_load_admin');

--- a/wc-pakettikauppa.php
+++ b/wc-pakettikauppa.php
@@ -19,44 +19,50 @@
  */
 
 // Prevent direct access to this script
-if ( ! defined( 'ABSPATH' ) ) {
-  exit;
+if (!defined('ABSPATH')) {
+    exit;
 }
 
 // @TODO: Also check for other solutions to refer to plugin_basename and plugin_dir_path in includes/ directory
-define( 'WC_PAKETTIKAUPPA_BASENAME', plugin_basename( __FILE__ ) );
-define( 'WC_PAKETTIKAUPPA_DIR', plugin_dir_path( __FILE__ ) );
+define('WC_PAKETTIKAUPPA_BASENAME', plugin_basename(__FILE__));
+define('WC_PAKETTIKAUPPA_DIR', plugin_dir_path(__FILE__));
 
 /**
  * Load plugin textdomain
  *
  * @return void
  */
-function wc_pakettikauppa_load_textdomain() {
-  load_plugin_textdomain( 'wc-pakettikauppa', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
+function wc_pakettikauppa_load_textdomain()
+{
+    load_plugin_textdomain('wc-pakettikauppa', false, dirname(plugin_basename(__FILE__)) . '/languages/');
 }
-add_action( 'plugins_loaded', 'wc_pakettikauppa_load_textdomain' );
 
-require_once plugin_dir_path( __FILE__ ) . 'includes/class-wc-pakettikauppa-shipping-method.php';
+add_action('plugins_loaded', 'wc_pakettikauppa_load_textdomain');
+
+require_once plugin_dir_path(__FILE__) . 'includes/class-wc-pakettikauppa-shipping-method.php';
 
 /**
  * Load the WC_Pakettikauppa class when in frontend
  */
-function wc_pakettikauppa_load() {
-  if ( ! is_admin() ) {
-    require_once plugin_dir_path( __FILE__ ) . 'includes/class-wc-pakettikauppa.php';
-    $wc_pakettikauppa = new WC_Pakettikauppa();
-    $wc_pakettikauppa->load();
-  }
+function wc_pakettikauppa_load()
+{
+    if (!is_admin()) {
+        require_once plugin_dir_path(__FILE__) . 'includes/class-wc-pakettikauppa.php';
+        $wc_pakettikauppa = new WC_Pakettikauppa();
+        $wc_pakettikauppa->load();
+    }
 }
-add_action( 'init', 'wc_pakettikauppa_load' );
+
+add_action('init', 'wc_pakettikauppa_load');
 
 /**
  * Load the WC_Pakettikauppa_Admin class in wp-admin
  */
-function wc_pakettikauppa_load_admin() {
-  require_once plugin_dir_path( __FILE__ ) . 'includes/class-wc-pakettikauppa-admin.php';
-  $wc_pakettikauppa_admin = new WC_Pakettikauppa_Admin();
-  $wc_pakettikauppa_admin->load();
+function wc_pakettikauppa_load_admin()
+{
+    require_once plugin_dir_path(__FILE__) . 'includes/class-wc-pakettikauppa-admin.php';
+    $wc_pakettikauppa_admin = new WC_Pakettikauppa_Admin();
+    $wc_pakettikauppa_admin->load();
 }
-add_action( 'admin_init', 'wc_pakettikauppa_load_admin' );
+
+add_action('admin_init', 'wc_pakettikauppa_load_admin');

--- a/wc-pakettikauppa.php
+++ b/wc-pakettikauppa.php
@@ -19,47 +19,47 @@
  */
 
 // Prevent direct access to this script
-if ( ! defined ('ABSPATH')) {
-    exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
 }
 
 // @TODO: Also check for other solutions to refer to plugin_basename and plugin_dir_path in includes/ directory
-define ('WC_PAKETTIKAUPPA_BASENAME', plugin_basename (__FILE__));
-define ('WC_PAKETTIKAUPPA_DIR', plugin_dir_path (__FILE__));
+define( 'WC_PAKETTIKAUPPA_BASENAME', plugin_basename( __FILE__ ) );
+define( 'WC_PAKETTIKAUPPA_DIR', plugin_dir_path( __FILE__ ) );
 
 /**
  * Load plugin textdomain
  *
  * @return void
  */
-function wc_pakettikauppa_load_textdomain () {
-    load_plugin_textdomain ('wc-pakettikauppa', false, dirname (plugin_basename (__FILE__)) . '/languages/');
+function wc_pakettikauppa_load_textdomain() {
+	load_plugin_textdomain( 'wc-pakettikauppa', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
 }
 
-add_action ('plugins_loaded', 'wc_pakettikauppa_load_textdomain');
+add_action( 'plugins_loaded', 'wc_pakettikauppa_load_textdomain' );
 
-require_once plugin_dir_path (__FILE__) . 'includes/class-wc-pakettikauppa-shipping-method.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-wc-pakettikauppa-shipping-method.php';
 
 /**
  * Load the WC_Pakettikauppa class when in frontend
  */
-function wc_pakettikauppa_load () {
-    if ( ! is_admin ()) {
-        require_once plugin_dir_path (__FILE__) . 'includes/class-wc-pakettikauppa.php';
-        $wc_pakettikauppa = new WC_Pakettikauppa();
-        $wc_pakettikauppa->load ();
-    }
+function wc_pakettikauppa_load() {
+	if ( ! is_admin() ) {
+		require_once plugin_dir_path( __FILE__ ) . 'includes/class-wc-pakettikauppa.php';
+		$wc_pakettikauppa = new WC_Pakettikauppa();
+		$wc_pakettikauppa->load();
+	}
 }
 
-add_action ('init', 'wc_pakettikauppa_load');
+add_action( 'init', 'wc_pakettikauppa_load' );
 
 /**
  * Load the WC_Pakettikauppa_Admin class in wp-admin
  */
-function wc_pakettikauppa_load_admin () {
-    require_once plugin_dir_path (__FILE__) . 'includes/class-wc-pakettikauppa-admin.php';
-    $wc_pakettikauppa_admin = new WC_Pakettikauppa_Admin();
-    $wc_pakettikauppa_admin->load ();
+function wc_pakettikauppa_load_admin() {
+	require_once plugin_dir_path( __FILE__ ) . 'includes/class-wc-pakettikauppa-admin.php';
+	$wc_pakettikauppa_admin = new WC_Pakettikauppa_Admin();
+	$wc_pakettikauppa_admin->load();
 }
 
-add_action ('admin_init', 'wc_pakettikauppa_load_admin');
+add_action( 'admin_init', 'wc_pakettikauppa_load_admin' );

--- a/wc-pakettikauppa.php
+++ b/wc-pakettikauppa.php
@@ -19,7 +19,7 @@
  */
 
 // Prevent direct access to this script
-if (!defined('ABSPATH')) {
+if(!defined('ABSPATH')) {
     exit;
 }
 
@@ -32,8 +32,7 @@ define('WC_PAKETTIKAUPPA_DIR', plugin_dir_path(__FILE__));
  *
  * @return void
  */
-function wc_pakettikauppa_load_textdomain()
-{
+function wc_pakettikauppa_load_textdomain() {
     load_plugin_textdomain('wc-pakettikauppa', false, dirname(plugin_basename(__FILE__)) . '/languages/');
 }
 
@@ -44,9 +43,8 @@ require_once plugin_dir_path(__FILE__) . 'includes/class-wc-pakettikauppa-shippi
 /**
  * Load the WC_Pakettikauppa class when in frontend
  */
-function wc_pakettikauppa_load()
-{
-    if (!is_admin()) {
+function wc_pakettikauppa_load() {
+    if(!is_admin()) {
         require_once plugin_dir_path(__FILE__) . 'includes/class-wc-pakettikauppa.php';
         $wc_pakettikauppa = new WC_Pakettikauppa();
         $wc_pakettikauppa->load();
@@ -58,8 +56,7 @@ add_action('init', 'wc_pakettikauppa_load');
 /**
  * Load the WC_Pakettikauppa_Admin class in wp-admin
  */
-function wc_pakettikauppa_load_admin()
-{
+function wc_pakettikauppa_load_admin() {
     require_once plugin_dir_path(__FILE__) . 'includes/class-wc-pakettikauppa-admin.php';
     $wc_pakettikauppa_admin = new WC_Pakettikauppa_Admin();
     $wc_pakettikauppa_admin->load();


### PR DESCRIPTION
This PR includes fixes to many small bugs:
- fixed typos in variable name, missing html elements, wrong css -class
- reformatted code for easier reading
- removed possibility to change shipping method from admin order view
- removed possibility to change pickup point from admin order view
- removed saving shipping label to the filesystem, it is fetched from the Pakettikauppa server when needed => removed creation of the private dir
- added info code support
- filtering shipping methods based on the receivers country
- fixed shipping costs VAT calculation
- trimming inputs for pickup point search