### PR TITLE
Update PHPCS configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,14 +28,22 @@ before_script:
   - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
   # Install PHP_CodeSniffer with a specific version defined so that devs and Travis-CI will have exactly same standards
   - if [[ "$SNIFF" == "1" ]]; then export PHPCS_DIR=/tmp/phpcs; export PHPCS_VERSION=3.3.2; fi
-  - if [[ "$SNIFF" == "1" ]]; then export SNIFFS_DIR=/tmp/sniffs; export SNIFFS_VERSION=1.0.0; fi
-  # Install PHP_CodeSniffer
+  - if [[ "$SNIFF" == "1" ]]; then export WP_SNIFFS_DIR=/tmp/wp-sniffs; export WP_SNIFFS_VERSION=2.1.0; fi
+  - if [[ "$SNIFF" == "1" ]]; then export SECURITY_SNIFFS_DIR=/tmp/security-sniffs; export SECURITY_SNIFFS_VERSION=2.0.0; fi
+  - if [[ "$SNIFF" == "1" ]]; then export PHP_COMPATIBILITY_SNIFFS_DIR=/tmp/compatibility-sniffs; export PHP_COMPATIBILITY_SNIFFS_VERSION=9.1.1; fi
+   # Install PHP_CodeSniffer.
   - if [[ "$SNIFF" == "1" ]]; then wget https://github.com/squizlabs/PHP_CodeSniffer/archive/$PHPCS_VERSION.tar.gz -O $PHPCS_VERSION.tar.gz && tar -xf $PHPCS_VERSION.tar.gz && mv PHP_CodeSniffer-$PHPCS_VERSION $PHPCS_DIR; fi
   # Install WordPress Coding Standards.
-  - if [[ "$SNIFF" == "1" ]]; then wget https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/archive/$SNIFFS_VERSION.tar.gz -O $SNIFFS_VERSION.tar.gz && tar -xf $SNIFFS_VERSION.tar.gz && mv WordPress-Coding-Standards-$SNIFFS_VERSION $SNIFFS_DIR; fi
-  # Set install path for WordPress Coding Standards
-  - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/bin/phpcs --config-set installed_paths $SNIFFS_DIR; fi
-  # After CodeSniffer install you should refresh your path
+  - if [[ "$SNIFF" == "1" ]]; then wget https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/archive/$WP_SNIFFS_VERSION.tar.gz -O $WP_SNIFFS_VERSION.tar.gz && tar -xf $WP_SNIFFS_VERSION.tar.gz && mv WordPress-Coding-Standards-$WP_SNIFFS_VERSION $WP_SNIFFS_DIR; fi
+  # Install PHPCS Security Audit.
+  - if [[ "$SNIFF" == "1" ]]; then wget https://github.com/FloeDesignTechnologies/phpcs-security-audit/archive/$SECURITY_SNIFFS_VERSION.tar.gz -O $SECURITY_SNIFFS_VERSION.tar.gz && tar -xf $SECURITY_SNIFFS_VERSION.tar.gz && mv phpcs-security-audit-$SECURITY_SNIFFS_VERSION $SECURITY_SNIFFS_DIR; fi
+  # Install PHP Compatibility.
+  - if [[ "$SNIFF" == "1" ]]; then wget https://github.com/PHPCompatibility/PHPCompatibility/archive/$PHP_COMPATIBILITY_SNIFFS_VERSION.tar.gz -O $PHP_COMPATIBILITY_SNIFFS_VERSION.tar.gz && tar -xf $PHP_COMPATIBILITY_SNIFFS_VERSION.tar.gz && mv PHPCompatibility-$PHP_COMPATIBILITY_SNIFFS_VERSION $PHP_COMPATIBILITY_SNIFFS_DIR; fi
+  # Set install path for sniffs.
+  - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/bin/phpcs --config-set installed_paths $WP_SNIFFS_DIR,$SECURITY_SNIFFS_DIR,$PHP_COMPATIBILITY_SNIFFS_DIR; fi
+  # Show installed sniffs
+  - if [[ "$SNIFF" == "1" ]]; then ${PHPCS_DIR}/bin/phpcs -i; fi
+  # After CodeSniffer install you should refresh your path.
   - if [[ "$SNIFF" == "1" ]]; then phpenv rehash; fi
 
 script:

--- a/assets/js/wc-pakettikauppa-admin.js
+++ b/assets/js/wc-pakettikauppa-admin.js
@@ -1,6 +1,6 @@
 // phpcs:disable PEAR.Functions.FunctionCallSignature
 /* admin js */
-jQuery( function ( $ ) {
+jQuery(function( $ ) {
   window.pakettikauppa_meta_box_submit = function(obj) {
     $('#wc-pakettikauppa').block({
       message: null,

--- a/assets/js/wc-pakettikauppa-admin.js
+++ b/assets/js/wc-pakettikauppa-admin.js
@@ -1,3 +1,4 @@
+// phpcs:disable PEAR.Functions.FunctionCallSignature
 /* admin js */
 jQuery( function ( $ ) {
   window.pakettikauppa_meta_box_submit = function(obj) {

--- a/assets/js/wc-pakettikauppa.js
+++ b/assets/js/wc-pakettikauppa.js
@@ -1,3 +1,4 @@
+// phpcs:disable PEAR.Functions.FunctionCallSignature
 /**
  * Add frontend scripts to this file.
  */

--- a/includes/class-wc-pakettikauppa-admin.php
+++ b/includes/class-wc-pakettikauppa-admin.php
@@ -1,7 +1,7 @@
 <?php
 
 // Prevent direct access to this script
-if ( ! defined( 'ABSPATH' ) ) {
+if ( ! defined('ABSPATH') ) {
   exit();
 }
 
@@ -30,58 +30,58 @@ class WC_Pakettikauppa_Admin {
   }
 
   public function load() {
-    add_filter( 'plugin_action_links_' . WC_PAKETTIKAUPPA_BASENAME, array( $this, 'add_settings_link' ) );
-    add_filter( 'plugin_row_meta', array( $this, 'plugin_row_meta' ), 10, 2 );
-    add_filter( 'bulk_actions-edit-shop_order', array( $this, 'register_multi_create_orders' ) );
-    add_action( 'woocommerce_admin_order_actions_end', array( $this, 'register_quick_create_order' ), 10, 2 ); //to add print option at the end of each orders in orders page
-    add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
-    add_action( 'add_meta_boxes', array( $this, 'register_meta_boxes' ) );
-    add_action( 'admin_post_show_pakettikauppa', array( $this, 'show' ), 10 );
-    add_action( 'admin_post_quick_create_label', array( $this, 'create_multiple_shipments' ), 10 );
-    add_action( 'woocommerce_email_order_meta', array( $this, 'attach_tracking_to_email' ), 10, 4 );
-    add_action( 'woocommerce_admin_order_data_after_shipping_address', array( $this, 'show_pickup_point_in_admin_order_meta' ), 10, 1 );
-    add_action( 'admin_notices', array( $this, 'wc_pakettikauppa_updated' ), 10, 2 );
-    add_action( 'handle_bulk_actions-edit-shop_order', array( $this, 'create_multiple_shipments' ) ); // admin_action_{action name}
-    add_action( 'pakettikauppa_create_shipments', array( $this, 'hook_create_shipments' ), 10, 2 );
-    add_action( 'pakettikauppa_fetch_shipping_labels', array( $this, 'hook_fetch_shipping_labels' ), 10, 2 );
-    add_action( 'pakettikauppa_fetch_tracking_code', array( $this, 'hook_fetch_tracking_code' ), 10, 2 );
-    add_action( 'woocommerce_product_options_shipping', array( $this, 'add_custom_product_fields' ) );
-    add_action( 'woocommerce_process_product_meta', array( $this, 'save_custom_product_fields' ) );
-    add_action( 'wp_ajax_pakettikauppa_meta_box', array( $this, 'ajax_meta_box' ) );
+    add_filter('plugin_action_links_' . WC_PAKETTIKAUPPA_BASENAME, array( $this, 'add_settings_link' ));
+    add_filter('plugin_row_meta', array( $this, 'plugin_row_meta' ), 10, 2);
+    add_filter('bulk_actions-edit-shop_order', array( $this, 'register_multi_create_orders' ));
+    add_action('woocommerce_admin_order_actions_end', array( $this, 'register_quick_create_order' ), 10, 2); //to add print option at the end of each orders in orders page
+    add_action('admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ));
+    add_action('add_meta_boxes', array( $this, 'register_meta_boxes' ));
+    add_action('admin_post_show_pakettikauppa', array( $this, 'show' ), 10);
+    add_action('admin_post_quick_create_label', array( $this, 'create_multiple_shipments' ), 10);
+    add_action('woocommerce_email_order_meta', array( $this, 'attach_tracking_to_email' ), 10, 4);
+    add_action('woocommerce_admin_order_data_after_shipping_address', array( $this, 'show_pickup_point_in_admin_order_meta' ), 10, 1);
+    add_action('admin_notices', array( $this, 'wc_pakettikauppa_updated' ), 10, 2);
+    add_action('handle_bulk_actions-edit-shop_order', array( $this, 'create_multiple_shipments' )); // admin_action_{action name}
+    add_action('pakettikauppa_create_shipments', array( $this, 'hook_create_shipments' ), 10, 2);
+    add_action('pakettikauppa_fetch_shipping_labels', array( $this, 'hook_fetch_shipping_labels' ), 10, 2);
+    add_action('pakettikauppa_fetch_tracking_code', array( $this, 'hook_fetch_tracking_code' ), 10, 2);
+    add_action('woocommerce_product_options_shipping', array( $this, 'add_custom_product_fields' ));
+    add_action('woocommerce_process_product_meta', array( $this, 'save_custom_product_fields' ));
+    add_action('wp_ajax_pakettikauppa_meta_box', array( $this, 'ajax_meta_box' ));
 
     try {
       $this->wc_pakettikauppa_shipment = new WC_Pakettikauppa_Shipment();
       $this->wc_pakettikauppa_shipment->load();
 
     } catch ( Exception $e ) {
-      $this->add_error( $e->getMessage() );
-      $this->add_error_notice( $e->getMessage() );
+      $this->add_error($e->getMessage());
+      $this->add_error_notice($e->getMessage());
 
       return;
     }
   }
 
   public function ajax_meta_box() {
-    check_ajax_referer( 'pakettikauppa-meta-box', 'security' );
+    check_ajax_referer('pakettikauppa-meta-box', 'security');
 
-    $this->save_ajax_metabox ( $_POST['post_id'] );
-    $this->meta_box( get_post ( $_POST['post_id'] ) );
+    $this->save_ajax_metabox($_POST['post_id']);
+    $this->meta_box(get_post($_POST['post_id']));
     wp_die();
   }
 
   public function save_custom_product_fields( $post_id ) {
     $custom_fields = array( 'pakettikauppa_tariff_codes', 'pakettikauppa_country_of_origin' );
 
-    if ( ! ( isset( $_POST['woocommerce_meta_nonce'] ) && wp_verify_nonce( sanitize_key( $_POST['woocommerce_meta_nonce'] ), 'woocommerce_save_data' ) ) ) {
+    if ( ! (isset($_POST['woocommerce_meta_nonce']) && wp_verify_nonce(sanitize_key($_POST['woocommerce_meta_nonce']), 'woocommerce_save_data')) ) {
       return false;
     }
 
     foreach ( $custom_fields as $custom_field ) {
       $value = $_POST[ $custom_field ];
-      if ( ! empty( $value ) ) {
-        update_post_meta( $post_id, $custom_field, strtoupper( esc_attr( $value ) ) );
+      if ( ! empty($value) ) {
+        update_post_meta($post_id, $custom_field, strtoupper(esc_attr($value)));
       } else {
-        delete_post_meta( $post_id, $custom_field );
+        delete_post_meta($post_id, $custom_field);
       }
     }
   }
@@ -89,22 +89,22 @@ class WC_Pakettikauppa_Admin {
   public function add_custom_product_fields() {
     $args = array(
       'id' => 'pakettikauppa_tariff_codes',
-      'label' => __( 'HS tariff number', 'pakettikauppa' ),
+      'label' => __('HS tariff number', 'pakettikauppa'),
       'desc_tip' => true,
-      'description' => __( 'The HS tariff number must be based on the Harmonized Commodity Description and Coding System developed by the World Customs Organization.', 'pakettikauppa' ),
+      'description' => __('The HS tariff number must be based on the Harmonized Commodity Description and Coding System developed by the World Customs Organization.', 'pakettikauppa'),
     );
-    woocommerce_wp_text_input( $args );
+    woocommerce_wp_text_input($args);
 
     $args = array(
       'id' => 'pakettikauppa_country_of_origin',
-      'label' => __( 'Country of origin', 'pakettikauppa' ),
+      'label' => __('Country of origin', 'pakettikauppa'),
       'desc_tip' => true,
-      'description' => __( '"Country of origin" means the country where the goods originated, e.g. were produced/manufactured or assembled.', 'pakettikauppa' ),
+      'description' => __('"Country of origin" means the country where the goods originated, e.g. were produced/manufactured or assembled.', 'pakettikauppa'),
       'custom_attributes' => array(
         'maxlength' => '2',
       ),
     );
-    woocommerce_wp_text_input( $args );
+    woocommerce_wp_text_input($args);
   }
 
   /**
@@ -120,8 +120,8 @@ class WC_Pakettikauppa_Admin {
    * @param $tracking_code
    */
   public function hook_fetch_tracking_code( $order_id, &$tracking_code ) {
-    $order = new WC_Order( $order_id );
-    $tracking_code = get_post_meta( $order->get_id(), '_wc_pakettikauppa_tracking_code', true );
+    $order = new WC_Order($order_id);
+    $tracking_code = get_post_meta($order->get_id(), '_wc_pakettikauppa_tracking_code', true);
   }
 
   /**
@@ -151,11 +151,11 @@ class WC_Pakettikauppa_Admin {
    * @param $pdf
    */
   public function hook_fetch_shipping_labels( $order_ids, &$pdf ) {
-    $tracking_codes = $this->create_shipments( $order_ids );
+    $tracking_codes = $this->create_shipments($order_ids);
 
-    $contents = $this->fetch_shipping_labels( $tracking_codes );
+    $contents = $this->fetch_shipping_labels($tracking_codes);
 
-    $pdf = base64_decode( $contents->{'response.file'} );
+    $pdf = base64_decode($contents->{'response.file'});
   }
 
   /**
@@ -164,7 +164,7 @@ class WC_Pakettikauppa_Admin {
    * @return mixed
    */
   public function register_multi_create_orders( $bulk_actions ) {
-    $bulk_actions['pakettikauppa_create_multiple_shipping_labels'] = __( 'Create and fetch shipping labels', 'wc-pakettikauppa' );
+    $bulk_actions['pakettikauppa_create_multiple_shipping_labels'] = __('Create and fetch shipping labels', 'wc-pakettikauppa');
 
     return $bulk_actions;
   }
@@ -178,10 +178,10 @@ class WC_Pakettikauppa_Admin {
   public function register_quick_create_order( $order ) {
     $shipping_methods = $order->get_shipping_methods();
 
-    if ( ! empty( $shipping_methods ) ) {
-      $shipping_method = array_pop( $shipping_methods );
+    if ( ! empty($shipping_methods) ) {
+      $shipping_method = array_pop($shipping_methods);
 
-      if ( ! empty( $shipping_method ) ) {
+      if ( ! empty($shipping_method) ) {
         $method_id = $shipping_method->get_method_id();
 
         if ( $method_id === 'local_pickup' ) {
@@ -190,17 +190,17 @@ class WC_Pakettikauppa_Admin {
       }
     }
 
-    $document_url = wp_nonce_url( admin_url( 'admin-post.php?post[]=' . $order->get_id () . '&action=quick_create_label'), 'bulk-posts');
+    $document_url = wp_nonce_url(admin_url('admin-post.php?post[]=' . $order->get_id() . '&action=quick_create_label'), 'bulk-posts');
 
     $class = 'pakettikauppa_create_shipping_label';
 
     $actions = array(
-      'name'   => __( 'Create shipping label', 'wc-pakettikauppa' ),
+      'name'   => __('Create shipping label', 'wc-pakettikauppa'),
       'action' => 'pakettikauppa_create_shipping_label',
       'url'    => $document_url,
     );
 
-    printf( '<a class="button wc-action-button wc-action-button-%s %s" href="%s" title="%s" target="_blank">%s</a>', $class, $class, $actions['url'], $actions['name'], $actions['name'] );
+    printf('<a class="button wc-action-button wc-action-button-%s %s" href="%s" title="%s" target="_blank">%s</a>', $class, $class, $actions['url'], $actions['name'], $actions['name']);
   }
 
   /**
@@ -209,19 +209,19 @@ class WC_Pakettikauppa_Admin {
    * @throws Exception
    */
   public function create_multiple_shipments() {
-    if ( ! isset( $_REQUEST['post'] ) ) {
+    if ( ! isset($_REQUEST['post']) ) {
       return;
     }
 
-    if ( ! is_array( $_REQUEST['post'] ) ) {
+    if ( ! is_array($_REQUEST['post']) ) {
       return;
     }
 
-    if ( isset ( $_REQUEST['action2'] ) ) {
+    if ( isset($_REQUEST['action2']) ) {
       if ( $_REQUEST['action2'] !== 'pakettikauppa_create_multiple_shipping_labels' ) {
         return;
       }
-    } else if ( isset ( $_REQUEST['action'] ) ) {
+    } else if ( isset($_REQUEST['action']) ) {
       if ( $_REQUEST['action'] !== 'quick_create_label' ) {
         return;
       }
@@ -229,7 +229,7 @@ class WC_Pakettikauppa_Admin {
       return;
     }
 
-    if ( ! wp_verify_nonce( sanitize_key( $_REQUEST['_wpnonce'] ), 'bulk-posts' ) ) {
+    if ( ! wp_verify_nonce(sanitize_key($_REQUEST['_wpnonce']), 'bulk-posts') ) {
       return;
     }
 
@@ -238,27 +238,27 @@ class WC_Pakettikauppa_Admin {
     $contents = $this->fetch_shipping_labels($tracking_codes);
 
     if ( $contents->{'response.file'}->__toString() === '' ) {
-      esc_attr_e( 'Cannot find shipments with given shipment numbers.', 'wc-pakettikauppa' );
+      esc_attr_e('Cannot find shipments with given shipment numbers.', 'wc-pakettikauppa');
 
       return;
     }
 
-    $this->output_shipping_label( $contents, 'multiple-shipping-labels' );
+    $this->output_shipping_label($contents, 'multiple-shipping-labels');
   }
 
   private function fetch_shipping_labels( $tracking_codes ) {
-    return $this->wc_pakettikauppa_shipment->fetch_shipping_labels( $tracking_codes );
+    return $this->wc_pakettikauppa_shipment->fetch_shipping_labels($tracking_codes);
   }
 
   private function create_shipments( $order_ids ) {
     $tracking_codes = array();
 
     foreach ( $order_ids as $order_id ) {
-      $order = new WC_Order( $order_id );
-      $tracking_code = get_post_meta( $order->get_id(), '_wc_pakettikauppa_tracking_code', true );
+      $order = new WC_Order($order_id);
+      $tracking_code = get_post_meta($order->get_id(), '_wc_pakettikauppa_tracking_code', true);
 
-      if ( empty( $tracking_code ) ) {
-        $tracking_code = $this->create_shipment( $order );
+      if ( empty($tracking_code) ) {
+        $tracking_code = $this->create_shipment($order);
       }
 
       if ( $tracking_code !== null ) {
@@ -284,10 +284,10 @@ class WC_Pakettikauppa_Admin {
 
     $settings = $this->wc_pakettikauppa_shipment->get_settings();
 
-    if ( ! empty( $settings['pickup_points'] ) ) {
-      $pickup_points = json_decode( $settings['pickup_points'], true );
+    if ( ! empty($settings['pickup_points']) ) {
+      $pickup_points = json_decode($settings['pickup_points'], true);
 
-      if ( ! empty( $pickup_points ) ) {
+      if ( ! empty($pickup_points) ) {
         foreach ( $pickup_points as $shipping_method ) {
           foreach ( $shipping_method as $provider ) {
             if ( isset($provider['active']) && $provider['active'] === 'yes' ) {
@@ -300,7 +300,7 @@ class WC_Pakettikauppa_Admin {
 
     if ( ! $shipping_method_found ) {
       echo '<div class="updated warning">';
-      echo sprintf('<p>%s</p>', __( 'Pakettikauppa plugin has been installed/updated and no shipping methods are activated!'));
+      echo sprintf('<p>%s</p>', __('Pakettikauppa plugin has been installed/updated and no shipping methods are activated!'));
       echo '</div>';
     }
   }
@@ -311,8 +311,8 @@ class WC_Pakettikauppa_Admin {
    * @param string $message A message containing details about the error.
    */
   public function add_error( $message ) {
-    if ( ! empty( $message ) ) {
-      array_push( $this->errors, $message );
+    if ( ! empty($message) ) {
+      array_push($this->errors, $message);
     }
   }
 
@@ -329,7 +329,7 @@ class WC_Pakettikauppa_Admin {
    * Clear all existing errors that have been added via add_error().
    */
   public function clear_errors() {
-    unset( $this->errors );
+    unset($this->errors);
     $this->errors = array();
   }
 
@@ -337,11 +337,11 @@ class WC_Pakettikauppa_Admin {
    * Add an admin error notice to wp-admin.
    */
   public function add_error_notice( $message ) {
-    if ( ! empty( $message ) ) {
+    if ( ! empty($message) ) {
       $class = 'notice notice-error';
       /* translators: %s: Error message */
-      $print_error = wp_sprintf( __( 'An error occured: %s', 'wc-pakettikauppa' ), $message );
-      printf( '<div class="%1$s"><p>%2$s</p></div>', esc_attr( $class ), esc_html( $print_error ) );
+      $print_error = wp_sprintf(__('An error occured: %s', 'wc-pakettikauppa'), $message);
+      printf('<div class="%1$s"><p>%2$s</p></div>', esc_attr($class), esc_html($print_error));
     }
   }
 
@@ -356,14 +356,15 @@ class WC_Pakettikauppa_Admin {
   public static function plugin_row_meta( $links, $file ) {
     if ( $file === WC_PAKETTIKAUPPA_BASENAME ) {
       $row_meta = array(
-        'service' => sprintf( '<a href="%1$s" aria-label="%2$s">%3$s</a>',
-          esc_url( 'https://www.pakettikauppa.fi' ),
-          esc_attr__( 'Visit Pakettikauppa', 'wc-pakettikauppa' ),
-          esc_html__( 'Show site Pakettikauppa', 'wc-pakettikauppa' )
+        'service' => sprintf(
+          '<a href="%1$s" aria-label="%2$s">%3$s</a>',
+          esc_url('https://www.pakettikauppa.fi'),
+          esc_attr__('Visit Pakettikauppa', 'wc-pakettikauppa'),
+          esc_html__('Show site Pakettikauppa', 'wc-pakettikauppa')
         ),
       );
 
-      return array_merge( $links, $row_meta );
+      return array_merge($links, $row_meta);
     }
 
     return (array) $links;
@@ -373,10 +374,10 @@ class WC_Pakettikauppa_Admin {
    * Register meta boxes for WooCommerce order metapage.
    */
   public function register_meta_boxes() {
-    foreach ( wc_get_order_types( 'order-meta-boxes' ) as $type ) {
+    foreach ( wc_get_order_types('order-meta-boxes') as $type ) {
       add_meta_box(
         'wc-pakettikauppa',
-        esc_attr__( 'Pakettikauppa', 'wc-pakettikauppa' ),
+        esc_attr__('Pakettikauppa', 'wc-pakettikauppa'),
         array(
           $this,
           'meta_box',
@@ -392,8 +393,8 @@ class WC_Pakettikauppa_Admin {
    * Enqueue admin-specific styles and scripts.
    */
   public function admin_enqueue_scripts() {
-    wp_enqueue_style( 'wc_pakettikauppa_admin', plugin_dir_url( __FILE__ ) . '../assets/css/wc-pakettikauppa-admin.css', array(), WC_PAKETTIKAUPPA_VERSION );
-    wp_enqueue_script( 'wc_pakettikauppa_admin_js', plugin_dir_url( __FILE__ ) . '../assets/js/wc-pakettikauppa-admin.js', array( 'jquery' ), WC_PAKETTIKAUPPA_VERSION, true);
+    wp_enqueue_style('wc_pakettikauppa_admin', plugin_dir_url(__FILE__) . '../assets/css/wc-pakettikauppa-admin.css', array(), WC_PAKETTIKAUPPA_VERSION);
+    wp_enqueue_script('wc_pakettikauppa_admin_js', plugin_dir_url(__FILE__) . '../assets/js/wc-pakettikauppa-admin.js', array( 'jquery' ), WC_PAKETTIKAUPPA_VERSION, true);
   }
 
   /**
@@ -405,10 +406,10 @@ class WC_Pakettikauppa_Admin {
    * @return array The plugin settings page link appended to the already existing links
    */
   public function add_settings_link( $links ) {
-    $url  = admin_url( 'admin.php?page=wc-settings&tab=shipping&section=wc_pakettikauppa_shipping_method' );
-    $link = sprintf( '<a href="%1$s">%2$s</a>', $url, esc_attr__( 'Settings' ) );
+    $url  = admin_url('admin.php?page=wc-settings&tab=shipping&section=wc_pakettikauppa_shipping_method');
+    $link = sprintf('<a href="%1$s">%2$s</a>', $url, esc_attr__('Settings'));
 
-    return array_merge( array( $link ), $links );
+    return array_merge(array( $link ), $links);
   }
 
   /**
@@ -418,11 +419,11 @@ class WC_Pakettikauppa_Admin {
    * @param WC_Order $order The order that is currently being viewed in wp-admin
    */
   public function show_pickup_point_in_admin_order_meta( $order ) {
-    echo sprintf( '<p class="form-field"><strong>%s:</strong><br>', esc_attr__( 'Requested pickup point', 'wc-pakettikauppa' ) );
-    if ( $order->get_meta( '_pakettikauppa_pickup_point' ) ) {
-      echo esc_attr( $order->get_meta( '_pakettikauppa_pickup_point' ) );
+    echo sprintf('<p class="form-field"><strong>%s:</strong><br>', esc_attr__('Requested pickup point', 'wc-pakettikauppa'));
+    if ( $order->get_meta('_pakettikauppa_pickup_point') ) {
+      echo esc_attr($order->get_meta('_pakettikauppa_pickup_point'));
     } else {
-      echo esc_attr__( 'None' );
+      echo esc_attr__('None');
     }
     echo '</p>';
   }
@@ -433,45 +434,45 @@ class WC_Pakettikauppa_Admin {
    * @param $post
    */
   public function meta_box( $post ) {
-    $order = wc_get_order( $post->ID );
+    $order = wc_get_order($post->ID);
 
     if ( $order === null ) {
       return;
     }
 
-    if ( ! WC_Pakettikauppa_Shipment::validate_order_shipping_receiver( $order ) ) {
-      esc_attr_e( 'Please add shipping info to the order to manage Pakettikauppa shipments.', 'wc-pakettikauppa' );
+    if ( ! WC_Pakettikauppa_Shipment::validate_order_shipping_receiver($order) ) {
+      esc_attr_e('Please add shipping info to the order to manage Pakettikauppa shipments.', 'wc-pakettikauppa');
 
       return;
     }
 
     // The tracking code will only be available if the shipment label has been generated
-    $tracking_code = get_post_meta( $post->ID, '_wc_pakettikauppa_tracking_code', true );
-    $label_code = get_post_meta( $post->ID, '_wc_pakettikauppa_label_code', true );
-    $tracking_url = get_post_meta ( $post->ID, '_wc_pakettikauppa_tracking_url', true);
-    if ( empty( $tracking_url ) ) {
-      $tracking_url = WC_Pakettikauppa_Shipment::tracking_url( $tracking_code );
+    $tracking_code = get_post_meta($post->ID, '_wc_pakettikauppa_tracking_code', true);
+    $label_code = get_post_meta($post->ID, '_wc_pakettikauppa_label_code', true);
+    $tracking_url = get_post_meta($post->ID, '_wc_pakettikauppa_tracking_url', true);
+    if ( empty($tracking_url) ) {
+      $tracking_url = WC_Pakettikauppa_Shipment::tracking_url($tracking_code);
     }
 
-    $service_id = get_post_meta ( $post->ID, '_wc_pakettikauppa_custom_service_id', true);
+    $service_id = get_post_meta($post->ID, '_wc_pakettikauppa_custom_service_id', true);
     $default_service_id = $this->get_service_id_from_order($order, false);
 
-    if ( empty( $service_id ) ) {
+    if ( empty($service_id) ) {
       $service_id = $default_service_id;
     }
 
-    $pickup_point_id = $order->get_meta( '_pakettikauppa_pickup_point_id' );
-    $status          = get_post_meta( $post->ID, '_wc_pakettikauppa_shipment_status', true );
+    $pickup_point_id = $order->get_meta('_pakettikauppa_pickup_point_id');
+    $status          = get_post_meta($post->ID, '_wc_pakettikauppa_shipment_status', true);
 
-    $document_url = admin_url( 'admin-post.php?post=' . $post->ID . '&action=show_pakettikauppa&tracking_code=' . $tracking_code );
+    $document_url = admin_url('admin-post.php?post=' . $post->ID . '&action=show_pakettikauppa&tracking_code=' . $tracking_code);
 
     $additional_services = array();
     if ( 'cod' === $order->get_payment_method() ) {
       $additional_services[] = '3101';
     }
 
-    foreach ( $this->get_additional_services( $order ) as $_additional_service ) {
-      $additional_services[] = key( $_additional_service );
+    foreach ( $this->get_additional_services($order) as $_additional_service ) {
+      $additional_services[] = key($_additional_service);
     }
 
     $additional_service_names = [
@@ -489,29 +490,29 @@ class WC_Pakettikauppa_Admin {
 
     ?>
     <div>
-      <?php if ( ! empty( $tracking_code ) ) : ?>
+      <?php if ( ! empty($tracking_code) ) : ?>
         <p class="pakettikauppa-shipment">
           <strong>
-            <?php echo esc_attr( $this->wc_pakettikauppa_shipment->service_title( $service_id ) ); ?><br />
-            <?php echo esc_attr( $tracking_code ); ?><br />
-            <?php echo esc_attr( WC_Pakettikauppa_Shipment::get_status_text( $status ) ); ?><br />
-            <?php if ( ! empty( $label_code ) ) : ?>
-              <?php echo __( 'Label code', 'wc-pakettikauppa' ); ?>: <?php echo $label_code; ?><br />
+            <?php echo esc_attr($this->wc_pakettikauppa_shipment->service_title($service_id)); ?><br />
+            <?php echo esc_attr($tracking_code); ?><br />
+            <?php echo esc_attr(WC_Pakettikauppa_Shipment::get_status_text($status)); ?><br />
+            <?php if ( ! empty($label_code) ) : ?>
+              <?php echo __('Label code', 'wc-pakettikauppa'); ?>: <?php echo $label_code; ?><br />
             <?php endif; ?>
           </strong>
           <br>
-          <a href="<?php echo esc_url( $document_url ); ?>" target="_blank" class="download"><?php esc_attr_e( 'Print document', 'wc-pakettikauppa' ); ?></a>&nbsp;-&nbsp;
-          <?php if ( ! empty( $tracking_url ) ) : ?>
-            <a href="<?php echo esc_url( $tracking_url ); ?>" target="_blank" class="tracking"><?php esc_attr_e( 'Track', 'wc-pakettikauppa' ); ?></a>
+          <a href="<?php echo esc_url($document_url); ?>" target="_blank" class="download"><?php esc_attr_e('Print document', 'wc-pakettikauppa'); ?></a>&nbsp;-&nbsp;
+          <?php if ( ! empty($tracking_url) ) : ?>
+            <a href="<?php echo esc_url($tracking_url); ?>" target="_blank" class="tracking"><?php esc_attr_e('Track', 'wc-pakettikauppa'); ?></a>
           <?php endif; ?>
         </p>
       <?php endif; ?>
-      <?php if ( empty( $tracking_code ) ) : ?>
+      <?php if ( empty($tracking_code) ) : ?>
         <div class="pakettikauppa-services">
           <fieldset class="pakettikauppa-metabox-fieldset" id="wc_pakettikauppa_shipping_method">
-            <h4><?php echo esc_html( $this->wc_pakettikauppa_shipment->service_title( $default_service_id ) ); ?></h4>
-            <?php if ( ! empty( $additional_services ) ) : ?>
-              <h4><?php echo esc_attr__('Additional services', 'wc-pakettikauppa' ); ?>:</h4>
+            <h4><?php echo esc_html($this->wc_pakettikauppa_shipment->service_title($default_service_id)); ?></h4>
+            <?php if ( ! empty($additional_services) ) : ?>
+              <h4><?php echo esc_attr__('Additional services', 'wc-pakettikauppa'); ?>:</h4>
               <ol style="list-style: circle;">
                 <?php foreach ( $additional_services as $i => $additional_service ) : ?>
                   <?php if ( $additional_service != '3102' ) : ?>
@@ -520,9 +521,9 @@ class WC_Pakettikauppa_Admin {
                     </li>
                   <?php endif; ?>
                 <?php endforeach; ?>
-                <?php if ( in_array( '3102', $additional_services ) ) : ?>
+                <?php if ( in_array('3102', $additional_services) ) : ?>
                   <li>
-                    <?php echo esc_html__( 'Parcel count', 'wc-pakettikauppa' ); ?>:
+                    <?php echo esc_html__('Parcel count', 'wc-pakettikauppa'); ?>:
                     <input type="number" name="wc_pakettikauppa_mps_count" value="1" style="width: 3em;" min="1" step="1" max="15">
                   </li>
                 <?php endif; ?>
@@ -531,24 +532,24 @@ class WC_Pakettikauppa_Admin {
 
             <?php if ( $pickup_point_id ) : ?>
               <h4>
-                <?php echo esc_html__( 'Requested pickup point', 'wc-pakettikauppa' ); ?>
+                <?php echo esc_html__('Requested pickup point', 'wc-pakettikauppa'); ?>
               </h4>
               <p>
-                <?php echo esc_html( $order->get_meta( '_pakettikauppa_pickup_point' ) ); ?>
+                <?php echo esc_html($order->get_meta('_pakettikauppa_pickup_point')); ?>
               </p>
             <?php endif; ?>
           </fieldset>
 
           <fieldset class="pakettikauppa-metabox-fieldset" id="wc_pakettikauppa_custom_shipping_method" style="display: none;">
             <select name="wc_pakettikauppa_service_id" id="pakettikauppa-service" class="pakettikauppa_metabox_values" onchange="pakettikauppa_change_shipping_method();">
-              <option value="__NULL__"><?php esc_html_e( 'No shipping', 'wc-pakettikauppa'); ?></option>
+              <option value="__NULL__"><?php esc_html_e('No shipping', 'wc-pakettikauppa'); ?></option>
               <?php foreach ( $this->wc_pakettikauppa_shipment->services() as $_service_code => $_service_title ) : ?>
                 <option
-                  <?php if ( strval ( $_service_code ) === $service_id ) : ?>
+                  <?php if ( strval($_service_code) === $service_id ) : ?>
                         selected="selected"
                   <?php endif; ?>
-                        value="<?php echo esc_attr( $_service_code ); ?>">
-                  <?php echo esc_html ( $_service_title ); ?>
+                        value="<?php echo esc_attr($_service_code); ?>">
+                  <?php echo esc_html($_service_title); ?>
                 </option>
               <?php endforeach; ?>
             </select>
@@ -558,7 +559,7 @@ class WC_Pakettikauppa_Admin {
               <ol style="list-style: circle; display: none;" class="pk-admin-additional-services" id="pk-admin-additional-services-<?php echo $method_code; ?>">
                 <?php $show_3102 = false; ?>
                 <?php foreach ( $_additional_services as $additional_service ) : ?>
-                  <?php if ( empty( $additional_service->specifiers ) ) : ?>
+                  <?php if ( empty($additional_service->specifiers) ) : ?>
                     <li>
                       <input
                               type="checkbox"
@@ -572,7 +573,7 @@ class WC_Pakettikauppa_Admin {
                 <?php endforeach; ?>
                 <?php if ( $show_3102 ) : ?>
                   <li>
-                    <?php echo esc_html__( 'Parcel count', 'wc-pakettikauppa' ); ?>:
+                    <?php echo esc_html__('Parcel count', 'wc-pakettikauppa'); ?>:
                     <input class="pakettikauppa_metabox_values" type="number" name="wc_pakettikauppa_mps_count" value="1" style="width: 3em;" min="1" step="1" max="15">
                   </li>
                 <?php endif; ?>
@@ -582,19 +583,19 @@ class WC_Pakettikauppa_Admin {
         </div>
         <p>
           <button type="button" value="create" name="wc_pakettikauppa[create]" class="button pakettikauppa_meta_box" onclick="pakettikauppa_meta_box_submit(this);">
-            <?php echo __( 'Create', 'wc-pakettikauppa' ); ?>
+            <?php echo __('Create', 'wc-pakettikauppa'); ?>
           </button>
           <button type="button" value="change" class="button pakettikauppa_meta_box" onclick="pakettikauppa_change_method(this);">
-            <?php echo __( 'Change shipping...', 'wc-pakettikauppa' ); ?>
+            <?php echo __('Change shipping...', 'wc-pakettikauppa'); ?>
           </button>
         </p>
       <?php else : ?>
         <p>
-          <button type="button" value="get_status" name="wc_pakettikauppa[get_status]" class="button pakettikauppa_meta_box" onclick="pakettikauppa_meta_box_submit(this);"><?php echo __( 'Update Status', 'wc-pakettikauppa' ); ?></button>
-          <button type="button" value="delete_shipping_label" name="wc_pakettikauppa[delete_shipping_label]" onclick="pakettikauppa_meta_box_submit(this);" class="button pakettikauppa_meta_box wc-pakettikauppa-delete-button"><?php echo __( 'Delete Shipping Label', 'wc-pakettikauppa' ); ?></button>
+          <button type="button" value="get_status" name="wc_pakettikauppa[get_status]" class="button pakettikauppa_meta_box" onclick="pakettikauppa_meta_box_submit(this);"><?php echo __('Update Status', 'wc-pakettikauppa'); ?></button>
+          <button type="button" value="delete_shipping_label" name="wc_pakettikauppa[delete_shipping_label]" onclick="pakettikauppa_meta_box_submit(this);" class="button pakettikauppa_meta_box wc-pakettikauppa-delete-button"><?php echo __('Delete Shipping Label', 'wc-pakettikauppa'); ?></button>
         </p>
       <?php endif; ?>
-      <input type="hidden" name="pakettikauppa_nonce" value="<?php echo wp_create_nonce( 'pakettikauppa-meta-box' ); ?>" id="pakettikauppa_metabox_nonce" />
+      <input type="hidden" name="pakettikauppa_nonce" value="<?php echo wp_create_nonce('pakettikauppa-meta-box'); ?>" id="pakettikauppa_metabox_nonce" />
     </div>
     <?php
   }
@@ -607,66 +608,66 @@ class WC_Pakettikauppa_Admin {
      * Because this function is called everytime something is saved in WooCommerce, then let's check this first
      * so it won't slow down saving other stuff too much.
      */
-    if ( ! isset( $_POST['wc_pakettikauppa'] ) ) {
+    if ( ! isset($_POST['wc_pakettikauppa']) ) {
       return;
     }
 
-    if ( ! check_ajax_referer( 'pakettikauppa-meta-box', 'security' ) ) {
+    if ( ! check_ajax_referer('pakettikauppa-meta-box', 'security') ) {
       return;
     }
 
-    if ( ! current_user_can( 'edit_post', $post_id ) ) {
+    if ( ! current_user_can('edit_post', $post_id) ) {
       return;
     }
 
-    if ( wp_is_post_autosave( $post_id ) ) {
+    if ( wp_is_post_autosave($post_id) ) {
       return;
     }
 
-    if ( wp_is_post_revision( $post_id ) ) {
+    if ( wp_is_post_revision($post_id) ) {
       return;
     }
 
-    $order = new WC_Order( $post_id );
+    $order = new WC_Order($post_id);
 
-    $command = key( $_POST['wc_pakettikauppa'] );
+    $command = key($_POST['wc_pakettikauppa']);
 
     $service_id = null;
 
     switch ( $command ) {
       case 'create':
-        if ( ! empty( $_REQUEST['wc_pakettikauppa_service_id'] ) ) {
+        if ( ! empty($_REQUEST['wc_pakettikauppa_service_id']) ) {
           $service_id = $_REQUEST['wc_pakettikauppa_service_id'];
         }
 
-        if ( empty( $_REQUEST['custom_method'] ) ) {
-          $pickup_point_id = $order->get_meta( '_pakettikauppa_pickup_point_id' );
+        if ( empty($_REQUEST['custom_method']) ) {
+          $pickup_point_id = $order->get_meta('_pakettikauppa_pickup_point_id');
 
-          if ( empty( $pickup_point_id ) && ! empty( $_REQUEST['wc_pakettikauppa_pickup_point_id'] ) ) {
+          if ( empty($pickup_point_id) && ! empty($_REQUEST['wc_pakettikauppa_pickup_point_id']) ) {
             $pickup_point_id = $_REQUEST['wc_pakettikauppa_pickup_point_id'];
 
-            update_post_meta( $order->get_id(), '_pakettikauppa_pickup_point_id', $pickup_point_id );
+            update_post_meta($order->get_id(), '_pakettikauppa_pickup_point_id', $pickup_point_id);
           }
         } else {
           $additional_services = array();
 
-          if ( ! empty( $_REQUEST['additional_services'] ) ) {
+          if ( ! empty($_REQUEST['additional_services']) ) {
             foreach ( $_REQUEST['additional_services'] as $_additional_service_code ) {
               $additional_services[] = array( $_additional_service_code => null );
             }
           }
 
-          if ( ! empty( $_REQUEST['wc_pakettikauppa_mps_count'] ) ) {
+          if ( ! empty($_REQUEST['wc_pakettikauppa_mps_count']) ) {
             $additional_services[] = array( '3102' => array( 'count' => $_REQUEST['wc_pakettikauppa_mps_count'] ) );
           }
         }
 
-        return $this->create_shipment( $order, $service_id, $additional_services );
+        return $this->create_shipment($order, $service_id, $additional_services);
       case 'get_status':
-        $this->get_status( $order );
+        $this->get_status($order);
         break;
       case 'delete_shipping_label':
-        $this->delete_shipping_label( $order );
+        $this->delete_shipping_label($order);
         break;
     }
   }
@@ -677,21 +678,24 @@ class WC_Pakettikauppa_Admin {
   private function delete_shipping_label( WC_Order $order ) {
     try {
       // Delete old tracking code
-      update_post_meta( $order->get_id(), '_wc_pakettikauppa_tracking_code', '' );
+      update_post_meta($order->get_id(), '_wc_pakettikauppa_tracking_code', '');
 
-      $order->add_order_note( esc_attr__( 'Successfully deleted Pakettikauppa shipping label.', 'wc-pakettikauppa' ) );
+      $order->add_order_note(esc_attr__('Successfully deleted Pakettikauppa shipping label.', 'wc-pakettikauppa'));
 
     } catch ( Exception $e ) {
-      $this->add_error( $e->getMessage() );
-      add_action( 'admin_notices', function() {
-        /* translators: %s: Error message */
-        $this->add_error_notice( wp_sprintf( esc_attr__( 'An error occured: %s', 'wc-pakettikauppa' ), $e->getMessage() ) );
-      } );
+      $this->add_error($e->getMessage());
+      add_action(
+        'admin_notices',
+        function() {
+          /* translators: %s: Error message */
+          $this->add_error_notice(wp_sprintf(esc_attr__('An error occured: %s', 'wc-pakettikauppa'), $e->getMessage()));
+        }
+      );
 
       $order->add_order_note(
         sprintf(
           /* translators: %s: Error message */
-          esc_attr__( 'Deleting Pakettikauppa shipment failed! Errors: %s', 'wc-pakettikauppa' ),
+          esc_attr__('Deleting Pakettikauppa shipment failed! Errors: %s', 'wc-pakettikauppa'),
           $e->getMessage()
         )
       );
@@ -703,14 +707,17 @@ class WC_Pakettikauppa_Admin {
    */
   private function get_status( WC_Order $order ) {
     try {
-      $status_code = $this->wc_pakettikauppa_shipment->get_shipment_status( $order->get_id() );
-      update_post_meta( $order->get_id(), '_wc_pakettikauppa_shipment_status', $status_code );
+      $status_code = $this->wc_pakettikauppa_shipment->get_shipment_status($order->get_id());
+      update_post_meta($order->get_id(), '_wc_pakettikauppa_shipment_status', $status_code);
     } catch ( Exception $e ) {
-      $this->add_error( $e->getMessage() );
-      add_action( 'admin_notices', function() {
-        /* translators: %s: Error message */
-        $this->add_error_notice( wp_sprintf( esc_attr__( 'An error occured: %s', 'wc-pakettikauppa' ), $e->getMessage() ) );
-      } );
+      $this->add_error($e->getMessage());
+      add_action(
+        'admin_notices',
+        function() {
+          /* translators: %s: Error message */
+          $this->add_error_notice(wp_sprintf(esc_attr__('An error occured: %s', 'wc-pakettikauppa'), $e->getMessage()));
+        }
+      );
     }
   }
 
@@ -719,28 +726,28 @@ class WC_Pakettikauppa_Admin {
       return null;
     }
 
-    $service_id = get_post_meta( $order->get_id(), '_wc_pakettikauppa_service_id', true );
+    $service_id = get_post_meta($order->get_id(), '_wc_pakettikauppa_service_id', true);
 
-    if ( empty( $service_id ) ) {
+    if ( empty($service_id) ) {
       $shipping_methods = $order->get_shipping_methods();
 
-      $shipping_method = array_pop( $shipping_methods );
+      $shipping_method = array_pop($shipping_methods);
 
-      if ( ! empty( $shipping_method ) ) {
-        $service_id = $shipping_method->get_meta( 'service_code' );
+      if ( ! empty($shipping_method) ) {
+        $service_id = $shipping_method->get_meta('service_code');
       }
     }
 
-    if ( empty( $service_id ) ) {
-      $service_id = get_post_meta( $order->get_id(), '_pakettikauppa_pickup_point_provider_id', true );
+    if ( empty($service_id) ) {
+      $service_id = get_post_meta($order->get_id(), '_pakettikauppa_pickup_point_provider_id', true);
     }
 
-    if ( empty( $service_id ) ) {
+    if ( empty($service_id) ) {
       $shipping_methods = $order->get_shipping_methods();
 
-      $chosen_shipping_method = array_pop( $shipping_methods );
+      $chosen_shipping_method = array_pop($shipping_methods);
 
-      if ( ! empty( $chosen_shipping_method ) ) {
+      if ( ! empty($chosen_shipping_method) ) {
         $method_id = $chosen_shipping_method->get_method_id();
 
         if ( $method_id === 'local_pickup' ) {
@@ -751,9 +758,9 @@ class WC_Pakettikauppa_Admin {
 
         $settings = $this->wc_pakettikauppa_shipment->get_settings();
 
-        $pickup_points = json_decode( $settings['pickup_points'], true );
+        $pickup_points = json_decode($settings['pickup_points'], true);
 
-        if ( ! empty( $pickup_points[ $instance_id ]['service'] ) ) {
+        if ( ! empty($pickup_points[ $instance_id ]['service']) ) {
           $service_id = $pickup_points[ $instance_id ]['service'];
         }
       }
@@ -763,7 +770,7 @@ class WC_Pakettikauppa_Admin {
       return null;
     }
 
-    if ( empty( $service_id ) && $return_default_shipping_method ) {
+    if ( empty($service_id) && $return_default_shipping_method ) {
       $service_id = WC_Pakettikauppa_Shipment::get_default_service();
     }
 
@@ -777,9 +784,9 @@ class WC_Pakettikauppa_Admin {
 
     $shipping_methods = $order->get_shipping_methods();
 
-    $chosen_shipping_method = array_pop( $shipping_methods );
+    $chosen_shipping_method = array_pop($shipping_methods);
 
-    if ( ! empty( $chosen_shipping_method ) ) {
+    if ( ! empty($chosen_shipping_method) ) {
       $method_id = $chosen_shipping_method->get_method_id();
 
       if ( $method_id === 'local_pickup' ) {
@@ -788,14 +795,14 @@ class WC_Pakettikauppa_Admin {
 
       $instance_id = $chosen_shipping_method->get_instance_id();
 
-      $pickup_points = json_decode( $settings['pickup_points'], true );
+      $pickup_points = json_decode($settings['pickup_points'], true);
 
-      if ( ! empty( $pickup_points[ $instance_id ]['service'] ) ) {
+      if ( ! empty($pickup_points[ $instance_id ]['service']) ) {
         $service_id = $pickup_points[ $instance_id ]['service'];
 
         $services = $pickup_points[ $instance_id ][ $service_id ]['additional_services'];
 
-        if ( ! empty( $services ) ) {
+        if ( ! empty($services) ) {
           foreach ( $services as $service_code => $service ) {
             if ( $service === 'yes' ) {
               $additional_services[] = array( $service_code => null );
@@ -814,32 +821,35 @@ class WC_Pakettikauppa_Admin {
    */
   private function create_shipment( WC_Order $order, $service_id = null, $additional_services = null ) {
     if ( $service_id === null ) {
-      $service_id = $this->get_service_id_from_order( $order );
+      $service_id = $this->get_service_id_from_order($order);
     }
 
-    if ( empty( $service_id ) || $service_id === '__NULL__' ) {
-      $order->add_order_note(esc_attr__( 'The shipping label was not created because the order does not contain valid shipping method.', 'wc-pakettikauppa' ) );
+    if ( empty($service_id) || $service_id === '__NULL__' ) {
+      $order->add_order_note(esc_attr__('The shipping label was not created because the order does not contain valid shipping method.', 'wc-pakettikauppa'));
 
       return null;
     }
 
     // Bail out if the receiver has not been properly configured
-    if ( ! WC_Pakettikauppa_Shipment::validate_order_shipping_receiver( $order ) ) {
-      add_action( 'admin_notices', function() {
-        echo '<div class="update-nag notice">' .
-             esc_attr__( 'The shipping label was not created because the order does not contain valid shipping details.', 'wc-pakettikauppa' ) .
+    if ( ! WC_Pakettikauppa_Shipment::validate_order_shipping_receiver($order) ) {
+      add_action(
+        'admin_notices',
+        function() {
+          echo '<div class="update-nag notice">' .
+             esc_attr__('The shipping label was not created because the order does not contain valid shipping details.', 'wc-pakettikauppa') .
              '</div>';
-      } );
+        }
+      );
 
       return null;
     }
 
     if ( $additional_services === null ) {
-      $additional_services = $this->get_additional_services( $order );
+      $additional_services = $this->get_additional_services($order);
 
-      $pickup_point_id = $order->get_meta( '_pakettikauppa_pickup_point_id' );
+      $pickup_point_id = $order->get_meta('_pakettikauppa_pickup_point_id');
 
-      if ( ! empty( $pickup_point_id ) ) {
+      if ( ! empty($pickup_point_id) ) {
         $additional_services[] = array(
           '2106' => array(
             'pickup_point_id' => $pickup_point_id,
@@ -849,59 +859,67 @@ class WC_Pakettikauppa_Admin {
     }
 
     try {
-      $shipment = $this->wc_pakettikauppa_shipment->create_shipment( $order, $service_id, $additional_services );
+      $shipment = $this->wc_pakettikauppa_shipment->create_shipment($order, $service_id, $additional_services);
       $tracking_code = $shipment->{'response.trackingcode'}->__toString();
     } catch ( Exception $e ) {
-      $this->add_error( $e->getMessage() );
+      $this->add_error($e->getMessage());
 
       /* translators: %s: Error message */
-      $order->add_order_note( sprintf( esc_attr__( 'Failed to create Pakettikauppa shipment. Errors: %s', 'wc-pakettikauppa' ), $e->getMessage() ) );
-      add_action( 'admin_notices', function() {
-        /* translators: %s: Error message */
-        $this->add_error_notice( wp_sprintf( esc_attr__( 'An error occured: %s', 'wc-pakettikauppa' ), $e->getMessage() ) );
-      } );
+      $order->add_order_note(sprintf(esc_attr__('Failed to create Pakettikauppa shipment. Errors: %s', 'wc-pakettikauppa'), $e->getMessage()));
+      add_action(
+        'admin_notices',
+        function() {
+          /* translators: %s: Error message */
+          $this->add_error_notice(wp_sprintf(esc_attr__('An error occured: %s', 'wc-pakettikauppa'), $e->getMessage()));
+        }
+      );
 
       return null;
     }
 
     if ( $tracking_code === null ) {
-      $order->add_order_note( esc_attr__( 'Failed to create Pakettikauppa shipment.', 'wc-pakettikauppa' ) );
-      add_action( 'admin_notices', function() {
-        /* translators: %s: Error message */
-        $this->add_error_notice( esc_attr__( 'Failed to create Pakettikauppa shipment.', 'wc-pakettikauppa' ) );
-      } );
+      $order->add_order_note(esc_attr__('Failed to create Pakettikauppa shipment.', 'wc-pakettikauppa'));
+      add_action(
+        'admin_notices',
+        function() {
+          /* translators: %s: Error message */
+          $this->add_error_notice(esc_attr__('Failed to create Pakettikauppa shipment.', 'wc-pakettikauppa'));
+        }
+      );
 
       return null;
     }
 
-    update_post_meta( $order->get_id(), '_wc_pakettikauppa_tracking_code', $tracking_code );
-    update_post_meta( $order->get_id(), '_wc_pakettikauppa_custom_service_id', $service_id );
+    update_post_meta($order->get_id(), '_wc_pakettikauppa_tracking_code', $tracking_code);
+    update_post_meta($order->get_id(), '_wc_pakettikauppa_custom_service_id', $service_id);
 
-    $document_url = admin_url( 'admin-post.php?post=' . $order->get_id() . '&action=show_pakettikauppa&tracking_code=' . $tracking_code );
+    $document_url = admin_url('admin-post.php?post=' . $order->get_id() . '&action=show_pakettikauppa&tracking_code=' . $tracking_code);
     $tracking_url = (string) $shipment->{'response.trackingcode'}['tracking_url'];
 
-    update_post_meta( $order->get_id(), '_wc_pakettikauppa_tracking_url', $tracking_url );
+    update_post_meta($order->get_id(), '_wc_pakettikauppa_tracking_url', $tracking_url);
 
     $label_code = (string) $shipment->{'response.trackingcode'}['labelcode'];
 
-    if ( ! empty( $label_code ) ) {
-      update_post_meta( $order->get_id(), '_wc_pakettikauppa_label_code', $label_code );
+    if ( ! empty($label_code) ) {
+      update_post_meta($order->get_id(), '_wc_pakettikauppa_label_code', $label_code);
     }
 
     // Add order note
-    $dl_link       = sprintf( '<a href="%1$s" target="_blank">%2$s</a>', $document_url, esc_attr__( 'Print document', 'wc-pakettikauppa' ) );
-    $tracking_link = sprintf( '<a href="%1$s" target="_blank">%2$s</a>', $tracking_url, __( 'Track', 'wc-pakettikauppa' ) );
+    $dl_link       = sprintf('<a href="%1$s" target="_blank">%2$s</a>', $document_url, esc_attr__('Print document', 'wc-pakettikauppa'));
+    $tracking_link = sprintf('<a href="%1$s" target="_blank">%2$s</a>', $tracking_url, __('Track', 'wc-pakettikauppa'));
 
-    $service_id = get_post_meta( $order->get_id(), '_wc_pakettikauppa_service_id', true );
+    $service_id = get_post_meta($order->get_id(), '_wc_pakettikauppa_service_id', true);
 
-    $order->add_order_note( sprintf(
-      /* translators: 1: Shipping service title 2: Shipment tracking code 3: Shipping label URL 4: Shipment tracking URL */
-      __( 'Created Pakettikauppa %1$s shipment.<br>%2$s<br>%1$s - %3$s<br>%4$s', 'wc-pakettikauppa' ),
-      $this->wc_pakettikauppa_shipment->service_title( $service_id ),
-      $tracking_code,
-      $dl_link,
-      $tracking_link
-    ) );
+    $order->add_order_note(
+      sprintf(
+        /* translators: 1: Shipping service title 2: Shipment tracking code 3: Shipping label URL 4: Shipment tracking URL */
+        __('Created Pakettikauppa %1$s shipment.<br>%2$s<br>%1$s - %3$s<br>%4$s', 'wc-pakettikauppa'),
+        $this->wc_pakettikauppa_shipment->service_title($service_id),
+        $tracking_code,
+        $dl_link,
+        $tracking_link
+      )
+    );
 
     return $tracking_code;
   }
@@ -913,22 +931,22 @@ class WC_Pakettikauppa_Admin {
     // Find shipment ID either from GET parameters or from the order
     // data.
     if ( empty( $_REQUEST['tracking_code'] ) ) { // @codingStandardsIgnoreLine
-      esc_attr_e( 'Shipment tracking code is not defined.', 'wc-pakettikauppa' );
+      esc_attr_e('Shipment tracking code is not defined.', 'wc-pakettikauppa');
 
       return;
     }
 
     $tracking_code = $_REQUEST['tracking_code']; // @codingStandardsIgnoreLine
 
-    $contents = $this->wc_pakettikauppa_shipment->fetch_shipping_label( $tracking_code );
+    $contents = $this->wc_pakettikauppa_shipment->fetch_shipping_label($tracking_code);
 
     if ( $contents->{'response.file'}->__toString() === '' ) {
-      esc_attr_e( 'Cannot find shipment with given shipment number.', 'wc-pakettikauppa' );
+      esc_attr_e('Cannot find shipment with given shipment number.', 'wc-pakettikauppa');
 
       return;
     }
 
-    $this->output_shipping_label( $contents, $tracking_code);
+    $this->output_shipping_label($contents, $tracking_code);
   }
 
   /**
@@ -936,8 +954,8 @@ class WC_Pakettikauppa_Admin {
    * @param $contents
    */
   private function output_shipping_label( $contents, $filename ) {
-    header( 'Content-type:application/pdf' );
-    header( "Content-Disposition:inline;filename={$filename}.pdf" );
+    header('Content-type:application/pdf');
+    header("Content-Disposition:inline;filename={$filename}.pdf");
 
     echo base64_decode( $contents->{'response.file'} ); // @codingStandardsIgnoreLine
 
@@ -957,33 +975,33 @@ class WC_Pakettikauppa_Admin {
     $add_to_email = $settings['add_tracking_to_email'];
     $add_pickup_point_to_email = $settings['add_pickup_point_to_email'];
 
-    if ( ! ( $add_to_email === 'yes' && isset( $email->id ) && $email->id === 'customer_completed_order' ) ) {
+    if ( ! ($add_to_email === 'yes' && isset($email->id) && $email->id === 'customer_completed_order') ) {
       return;
     }
 
-    $tracking_code = get_post_meta( $order->get_ID(), '_wc_pakettikauppa_tracking_code', true );
-    $tracking_url  = WC_Pakettikauppa_Shipment::tracking_url( $tracking_code );
+    $tracking_code = get_post_meta($order->get_ID(), '_wc_pakettikauppa_tracking_code', true);
+    $tracking_url  = WC_Pakettikauppa_Shipment::tracking_url($tracking_code);
 
-    if ( empty( $tracking_code ) || empty( $tracking_url ) ) {
+    if ( empty($tracking_code) || empty($tracking_url) ) {
       return;
     }
 
     if ( $plain_text ) {
       /* translators: %s: Shipment tracking URL */
-      if ( ! empty( $order->get_meta( '_pakettikauppa_pickup_point' ) ) && 'yes' === $add_pickup_point_to_email ) {
-        echo sprintf( "%s: %s\n\n", __( 'Requested pickup point', 'wc-pakettikauppa' ), $order->get_meta( '_pakettikauppa_pickup_point' ) );
+      if ( ! empty($order->get_meta('_pakettikauppa_pickup_point')) && 'yes' === $add_pickup_point_to_email ) {
+        echo sprintf("%s: %s\n\n", __('Requested pickup point', 'wc-pakettikauppa'), $order->get_meta('_pakettikauppa_pickup_point'));
       }
 
-      echo sprintf( __( "You can track your order at %1\$s.\n\n", 'wc-pakettikauppa' ), esc_url( $tracking_url ) );
+      echo sprintf(__("You can track your order at %1\$s.\n\n", 'wc-pakettikauppa'), esc_url($tracking_url));
     } else {
-      if ( ! empty( $order->get_meta( '_pakettikauppa_pickup_point' ) ) && 'yes' === $add_pickup_point_to_email ) {
-        echo sprintf( '<h2>%s</h2>', esc_attr__( 'Requested pickup point', 'wc-pakettikauppa' ) );
-        echo sprintf( '<p>%s</p>', esc_attr( $order->get_meta( '_pakettikauppa_pickup_point' ) ) );
+      if ( ! empty($order->get_meta('_pakettikauppa_pickup_point')) && 'yes' === $add_pickup_point_to_email ) {
+        echo sprintf('<h2>%s</h2>', esc_attr__('Requested pickup point', 'wc-pakettikauppa'));
+        echo sprintf('<p>%s</p>', esc_attr($order->get_meta('_pakettikauppa_pickup_point')));
       }
 
-      echo '<h2>' . esc_attr__( 'Tracking', 'wc-pakettikauppa' ) . '</h2>';
+      echo '<h2>' . esc_attr__('Tracking', 'wc-pakettikauppa') . '</h2>';
       /* translators: 1: Shipment tracking URL 2: Shipment tracking code */
-      echo '<p>' . sprintf( __( 'You can <a href="%1$s">track your order</a> with tracking code %2$s.', 'wc-pakettikauppa' ), esc_url( $tracking_url ), esc_attr( $tracking_code ) ) . '</p>';
+      echo '<p>' . sprintf(__('You can <a href="%1$s">track your order</a> with tracking code %2$s.', 'wc-pakettikauppa'), esc_url($tracking_url), esc_attr($tracking_code)) . '</p>';
     }
   }
 }

--- a/includes/class-wc-pakettikauppa-shipment.php
+++ b/includes/class-wc-pakettikauppa-shipment.php
@@ -4,7 +4,7 @@
  */
 
 // Prevent direct access to this script
-if ( ! defined( 'ABSPATH' ) ) {
+if ( ! defined('ABSPATH') ) {
   exit;
 }
 
@@ -49,49 +49,49 @@ class WC_Pakettikauppa_Shipment {
    * code is unknown.
    */
   public static function get_status_text( $status_code ) {
-    switch ( intval( $status_code ) ) {
+    switch ( intval($status_code) ) {
       case 13:
-        $status = __( 'Item is collected from sender - picked up', 'wc-pakettikauppa' );
+        $status = __('Item is collected from sender - picked up', 'wc-pakettikauppa');
         break;
       case 20:
-        $status = __( 'Exception', 'wc-pakettikauppa' );
+        $status = __('Exception', 'wc-pakettikauppa');
         break;
       case 22:
-        $status = __( 'Item has been handed over to the recipient', 'wc-pakettikauppa' );
+        $status = __('Item has been handed over to the recipient', 'wc-pakettikauppa');
         break;
       case 31:
-        $status = __( 'Item is in transport', 'wc-pakettikauppa' );
+        $status = __('Item is in transport', 'wc-pakettikauppa');
         break;
       case 38:
-        $status = __( 'C.O.D payment is paid to the sender', 'wc-pakettikauppa' );
+        $status = __('C.O.D payment is paid to the sender', 'wc-pakettikauppa');
         break;
       case 45:
-        $status = __( 'Informed consignee of arrival', 'wc-pakettikauppa' );
+        $status = __('Informed consignee of arrival', 'wc-pakettikauppa');
         break;
       case 48:
-        $status = __( 'Item is loaded onto a means of transport', 'wc-pakettikauppa' );
+        $status = __('Item is loaded onto a means of transport', 'wc-pakettikauppa');
         break;
       case 56:
-        $status = __( 'Item not delivered – delivery attempt made', 'wc-pakettikauppa' );
+        $status = __('Item not delivered – delivery attempt made', 'wc-pakettikauppa');
         break;
       case 68:
-        $status = __( 'Pre-information is received from sender', 'wc-pakettikauppa' );
+        $status = __('Pre-information is received from sender', 'wc-pakettikauppa');
         break;
       case 71:
-        $status = __( 'Item is ready for delivery transportation', 'wc-pakettikauppa' );
+        $status = __('Item is ready for delivery transportation', 'wc-pakettikauppa');
         break;
       case 77:
-        $status = __( 'Item is returning to the sender', 'wc-pakettikauppa' );
+        $status = __('Item is returning to the sender', 'wc-pakettikauppa');
         break;
       case 91:
-        $status = __( 'Item is arrived to a post office', 'wc-pakettikauppa' );
+        $status = __('Item is arrived to a post office', 'wc-pakettikauppa');
         break;
       case 99:
-        $status = __( 'Outbound', 'wc-pakettikauppa' );
+        $status = __('Outbound', 'wc-pakettikauppa');
         break;
       default:
         /* translators: %s: Status code */
-        $status = wp_sprintf( __( 'Unknown status: %s', 'wc-pakettikauppa' ), $status_code );
+        $status = wp_sprintf(__('Unknown status: %s', 'wc-pakettikauppa'), $status_code);
         break;
     }
 
@@ -108,7 +108,7 @@ class WC_Pakettikauppa_Shipment {
    */
   public static function tracking_url( $tracking_code ) {
 
-    if ( empty( $tracking_code ) ) {
+    if ( empty($tracking_code) ) {
       return '';
     }
     $tracking_url = 'https://www.pakettikauppa.fi/seuranta/?' . $tracking_code;
@@ -138,10 +138,10 @@ class WC_Pakettikauppa_Shipment {
    */
   public static function validate_order_shipping_receiver( $order ) {
     // Check shipping info first
-    $no_shipping_name     = (bool) empty( $order->get_formatted_shipping_full_name() );
-    $no_shipping_address  = (bool) empty( $order->get_shipping_address_1() ) && empty( $order->get_shipping_address_2() );
-    $no_shipping_postcode = (bool) empty( $order->get_shipping_postcode() );
-    $no_shipping_city     = (bool) empty( $order->get_shipping_city() );
+    $no_shipping_name     = (bool) empty($order->get_formatted_shipping_full_name());
+    $no_shipping_address  = (bool) empty($order->get_shipping_address_1()) && empty($order->get_shipping_address_2());
+    $no_shipping_postcode = (bool) empty($order->get_shipping_postcode());
+    $no_shipping_city     = (bool) empty($order->get_shipping_city());
 
     if ( $no_shipping_name || $no_shipping_address || $no_shipping_postcode || $no_shipping_city ) {
       return false;
@@ -152,7 +152,7 @@ class WC_Pakettikauppa_Shipment {
 
   public function load() {
     // Use option from database directly as WC_Pakettikauppa_Shipping_Method object is not accessible here
-    $settings = get_option( 'woocommerce_pakettikauppa_shipping_method_settings', null );
+    $settings = get_option('woocommerce_pakettikauppa_shipping_method_settings', null);
 
     if ( $settings === false ) {
       throw new Exception(
@@ -165,7 +165,7 @@ class WC_Pakettikauppa_Shipment {
     $account_number = $settings['account_number'];
     $secret_key     = $settings['secret_key'];
     $mode           = $settings['mode'];
-    $is_test_mode   = ( $mode === 'production' ? false : true );
+    $is_test_mode   = ($mode === 'production' ? false : true);
 
     $options_array = array(
       'api_key'   => $account_number,
@@ -173,8 +173,8 @@ class WC_Pakettikauppa_Shipment {
       'test_mode' => $is_test_mode,
     );
 
-    $this->wc_pakettikauppa_client = new Pakettikauppa\Client( $options_array );
-    $this->wc_pakettikauppa_client->setComment( 'From WooCommerce' );
+    $this->wc_pakettikauppa_client = new Pakettikauppa\Client($options_array);
+    $this->wc_pakettikauppa_client->setComment('From WooCommerce');
   }
 
   /**
@@ -185,14 +185,14 @@ class WC_Pakettikauppa_Shipment {
    * @return int The status code of the shipment
    */
   public function get_shipment_status( $post_id ) {
-    $tracking_code = get_post_meta( $post_id, '_wc_pakettikauppa_tracking_code', true );
+    $tracking_code = get_post_meta($post_id, '_wc_pakettikauppa_tracking_code', true);
 
-    if ( ! empty( $tracking_code ) ) {
-      $result = $this->wc_pakettikauppa_client->getShipmentStatus( $tracking_code );
+    if ( ! empty($tracking_code) ) {
+      $result = $this->wc_pakettikauppa_client->getShipmentStatus($tracking_code);
 
-      $data = json_decode( $result );
+      $data = json_decode($result);
 
-      if ( ! empty( $data ) && isset( $data[0] ) ) {
+      if ( ! empty($data) && isset($data[0]) ) {
         return $data[0]->{'status_code'};
       }
 
@@ -211,83 +211,83 @@ class WC_Pakettikauppa_Shipment {
   public function create_shipment( $order, $service_id = null, $additional_services = array() ) {
     $shipment   = new Shipment();
 
-    $shipment->setShippingMethod( $service_id );
+    $shipment->setShippingMethod($service_id);
 
     $sender = new Sender();
-    $sender->setName1( $this->wc_pakettikauppa_settings['sender_name'] );
-    $sender->setAddr1( $this->wc_pakettikauppa_settings['sender_address'] );
-    $sender->setPostcode( $this->wc_pakettikauppa_settings['sender_postal_code'] );
-    $sender->setCity( $this->wc_pakettikauppa_settings['sender_city'] );
-    $sender->setCountry( 'FI' );
-    $shipment->setSender( $sender );
+    $sender->setName1($this->wc_pakettikauppa_settings['sender_name']);
+    $sender->setAddr1($this->wc_pakettikauppa_settings['sender_address']);
+    $sender->setPostcode($this->wc_pakettikauppa_settings['sender_postal_code']);
+    $sender->setCity($this->wc_pakettikauppa_settings['sender_city']);
+    $sender->setCountry('FI');
+    $shipment->setSender($sender);
 
     $receiver = new Receiver();
-    $receiver->setName1( $order->get_formatted_shipping_full_name() );
-    $receiver->setAddr1( $order->get_shipping_address_1() );
-    $receiver->setAddr2( $order->get_shipping_address_2() );
-    $receiver->setPostcode( $order->get_shipping_postcode() );
-    $receiver->setCity( $order->get_shipping_city() );
-    $receiver->setCountry( ( $order->get_shipping_country() === null ? 'FI' : $order->get_shipping_country() ) );
-    $receiver->setEmail( $order->get_billing_email() );
-    $receiver->setPhone( $order->get_billing_phone() );
-    $shipment->setReceiver( $receiver );
+    $receiver->setName1($order->get_formatted_shipping_full_name());
+    $receiver->setAddr1($order->get_shipping_address_1());
+    $receiver->setAddr2($order->get_shipping_address_2());
+    $receiver->setPostcode($order->get_shipping_postcode());
+    $receiver->setCity($order->get_shipping_city());
+    $receiver->setCountry(($order->get_shipping_country() === null ? 'FI' : $order->get_shipping_country()));
+    $receiver->setEmail($order->get_billing_email());
+    $receiver->setPhone($order->get_billing_phone());
+    $shipment->setReceiver($receiver);
 
     $info = new Info();
-    $info->setReference( $order->get_order_number() );
-    $info->setCurrency( get_woocommerce_currency() );
-    $shipment->setShipmentInfo( $info );
+    $info->setReference($order->get_order_number());
+    $info->setCurrency(get_woocommerce_currency());
+    $shipment->setShipmentInfo($info);
 
     $parcel = new Parcel();
-    $parcel->setWeight( self::order_weight( $order ) );
-    $parcel->setVolume( self::order_volume( $order ) );
+    $parcel->setWeight(self::order_weight($order));
+    $parcel->setVolume(self::order_volume($order));
 
-    if ( ! empty( $this->wc_pakettikauppa_settings['info_code'] ) ) {
-      $parcel->setInfocode( $this->wc_pakettikauppa_settings['info_code'] );
+    if ( ! empty($this->wc_pakettikauppa_settings['info_code']) ) {
+      $parcel->setInfocode($this->wc_pakettikauppa_settings['info_code']);
     }
-    $shipment->addParcel( $parcel );
+    $shipment->addParcel($parcel);
 
     if ( 'cod' === $order->get_payment_method() ) {
       $additional_service = new AdditionalService();
-      $additional_service->setServiceCode( 3101 );
+      $additional_service->setServiceCode(3101);
 
-      $additional_service->addSpecifier( 'amount', $order->get_total() );
-      $additional_service->addSpecifier( 'account', $this->wc_pakettikauppa_settings['cod_iban'] );
-      $additional_service->addSpecifier( 'codbic', $this->wc_pakettikauppa_settings['cod_bic'] );
-      $additional_service->addSpecifier( 'reference', $this->calculate_reference( $order->get_id() ) );
+      $additional_service->addSpecifier('amount', $order->get_total());
+      $additional_service->addSpecifier('account', $this->wc_pakettikauppa_settings['cod_iban']);
+      $additional_service->addSpecifier('codbic', $this->wc_pakettikauppa_settings['cod_bic']);
+      $additional_service->addSpecifier('reference', $this->calculate_reference($order->get_id()));
 
-      $shipment->addAdditionalService( $additional_service );
+      $shipment->addAdditionalService($additional_service);
     }
 
     foreach ( $additional_services as $_additional_service ) {
       $additional_service = new AdditionalService();
-      $additional_service->setServiceCode( key($_additional_service) );
+      $additional_service->setServiceCode(key($_additional_service));
 
       foreach ( $_additional_service as $_additional_service_key => $_additional_service_config ) {
-        if ( ! empty( $_additional_service_config ) ) {
+        if ( ! empty($_additional_service_config) ) {
           foreach ( $_additional_service_config as $_name => $_value ) {
-            $additional_service->addSpecifier( $_name, $_value );
+            $additional_service->addSpecifier($_name, $_value);
           }
         }
       }
 
-      $shipment->addAdditionalService( $additional_service );
+      $shipment->addAdditionalService($additional_service);
     }
 
     $items = $order->get_items();
 
     $wcpf = new WC_Product_Factory();
 
-    if ( ! empty( $items ) ) {
+    if ( ! empty($items) ) {
       foreach ( $items as $item ) {
         $item_data = $item->get_data();
 
-        if ( empty( $item_data ) ) {
+        if ( empty($item_data) ) {
           continue;
         }
 
-        $product = $wcpf->get_product( $item_data['product_id'] );
+        $product = $wcpf->get_product($item_data['product_id']);
 
-        if ( empty( $product ) ) {
+        if ( empty($product) ) {
           continue;
         }
 
@@ -295,8 +295,8 @@ class WC_Pakettikauppa_Shipment {
           continue;
         }
 
-        $tariff_code       = $product->get_meta( 'pakettikauppa_tariff_codes', true );
-        $country_of_origin = $product->get_meta( 'pakettikauppa_country_of_origin', true );
+        $tariff_code       = $product->get_meta('pakettikauppa_tariff_codes', true);
+        $country_of_origin = $product->get_meta('pakettikauppa_country_of_origin', true);
 
         $content_line                    = new ContentLine();
         $content_line->currency          = 'EUR';
@@ -305,21 +305,21 @@ class WC_Pakettikauppa_Shipment {
         $content_line->description       = $product->get_name();
         $content_line->quantity          = $item->get_quantity();
 
-        if ( ! empty( $product->get_weight() ) ) {
-          $content_line->netweight = wc_get_weight( $product->get_weight() * $item->get_quantity(), 'g' );
+        if ( ! empty($product->get_weight()) ) {
+          $content_line->netweight = wc_get_weight($product->get_weight() * $item->get_quantity(), 'g');
         }
 
-        $content_line->value = round( $item_data['total'] + $item_data['total_tax'], 2 );
+        $content_line->value = round($item_data['total'] + $item_data['total_tax'], 2);
 
-        $parcel->addContentLine( $content_line );
+        $parcel->addContentLine($content_line);
       }
     }
 
     try {
-      $this->wc_pakettikauppa_client->createTrackingCode( $shipment );
+      $this->wc_pakettikauppa_client->createTrackingCode($shipment);
     } catch ( Exception $e ) {
       /* translators: %s: Error message */
-      throw new Exception( wp_sprintf( __( 'WooCommerce Pakettikauppa: tracking code creation failed: %s', 'wc-pakettikauppa' ), $e->getMessage() ) );
+      throw new Exception(wp_sprintf(__('WooCommerce Pakettikauppa: tracking code creation failed: %s', 'wc-pakettikauppa'), $e->getMessage()));
     }
 
     return $this->wc_pakettikauppa_client->getResponse();
@@ -338,21 +338,21 @@ class WC_Pakettikauppa_Shipment {
     $wcpf = new WC_Product_Factory();
 
     foreach ( $order->get_items() as $item ) {
-      if ( empty( $item['product_id'] ) ) {
+      if ( empty($item['product_id']) ) {
         continue;
       }
 
-      $product = $wcpf->get_product( $item['product_id'] );
+      $product = $wcpf->get_product($item['product_id']);
 
       if ( $product->is_virtual() ) {
         continue;
       }
 
-      if ( ! is_numeric( $product->get_weight() ) ) {
+      if ( ! is_numeric($product->get_weight()) ) {
         continue;
       }
 
-      $weight += wc_get_weight( $product->get_weight() * $item->get_quantity(), 'kg' );
+      $weight += wc_get_weight($product->get_weight() * $item->get_quantity(), 'kg');
     }
 
     return $weight;
@@ -371,24 +371,24 @@ class WC_Pakettikauppa_Shipment {
     $wcpf = new WC_Product_Factory();
 
     foreach ( $order->get_items() as $item ) {
-      if ( empty( $item['product_id'] ) ) {
+      if ( empty($item['product_id']) ) {
         continue;
       }
 
-      $product = $wcpf->get_product( $item['product_id'] );
+      $product = $wcpf->get_product($item['product_id']);
 
       if ( $product->is_virtual() ) {
         continue;
       }
 
-      if ( ! is_numeric( $product->get_width() )
-           || ! is_numeric( $product->get_height() )
-           || ! is_numeric( $product->get_length() ) ) {
+      if ( ! is_numeric($product->get_width())
+           || ! is_numeric($product->get_height())
+           || ! is_numeric($product->get_length()) ) {
         continue;
       }
 
       // Ensure that the volume is in metres
-      $woo_dim_unit = strtolower( get_option( 'woocommerce_dimension_unit' ) );
+      $woo_dim_unit = strtolower(get_option('woocommerce_dimension_unit'));
       switch ( $woo_dim_unit ) {
         case 'mm':
           $dim_multiplier = 0.001;
@@ -403,7 +403,7 @@ class WC_Pakettikauppa_Shipment {
           $dim_multiplier = 1;
       }
       // Calculate total volume
-      $volume += pow( $dim_multiplier, 3 ) * $product->get_width() * $product->get_height() * $product->get_length() * $item['qty'];
+      $volume += pow($dim_multiplier, 3) * $product->get_width() * $product->get_height() * $product->get_length() * $item['qty'];
     }
 
     return $volume;
@@ -421,17 +421,17 @@ class WC_Pakettikauppa_Shipment {
     $weights = array( 7, 3, 1 );
     $sum     = 0;
 
-    $base                 = str_split( strval( ( $id ) ) );
-    $reversed_base        = array_reverse( $base );
-    $reversed_base_length = count( $reversed_base );
+    $base                 = str_split(strval(($id)));
+    $reversed_base        = array_reverse($base);
+    $reversed_base_length = count($reversed_base);
 
     for ( $i = 0; $i < $reversed_base_length; $i ++ ) {
       $sum += $reversed_base[ $i ] * $weights[ $i % 3 ];
     }
 
-    $checksum = ( 10 - $sum % 10 ) % 10;
+    $checksum = (10 - $sum % 10) % 10;
 
-    $reference = implode( '', $base ) . $checksum;
+    $reference = implode('', $base) . $checksum;
 
     return $reference;
   }
@@ -443,7 +443,7 @@ class WC_Pakettikauppa_Shipment {
    * @throws Exception
    */
   public function fetch_shipping_labels( $tracking_codes ) {
-    return $this->wc_pakettikauppa_client->fetchShippingLabels( $tracking_codes );
+    return $this->wc_pakettikauppa_client->fetchShippingLabels($tracking_codes);
   }
 
   /**
@@ -453,7 +453,7 @@ class WC_Pakettikauppa_Shipment {
    * @throws Exception
    */
   public function fetch_shipping_label( $tracking_code ) {
-    return $this->fetch_shipping_labels( array( $tracking_code ) );
+    return $this->fetch_shipping_labels(array( $tracking_code ));
   }
 
   /**
@@ -470,13 +470,13 @@ class WC_Pakettikauppa_Shipment {
   public function get_pickup_points( $postcode, $street_address = null, $country = null, $service_provider = null ) {
     $pickup_point_limit = 5; // Default limit value for pickup point search
 
-    if ( isset( $this->wc_pakettikauppa_settings['pickup_points_search_limit'] ) && ! empty( $this->wc_pakettikauppa_settings['pickup_points_search_limit'] ) ) {
-      $pickup_point_limit = intval( $this->wc_pakettikauppa_settings['pickup_points_search_limit'] );
+    if ( isset($this->wc_pakettikauppa_settings['pickup_points_search_limit']) && ! empty($this->wc_pakettikauppa_settings['pickup_points_search_limit']) ) {
+      $pickup_point_limit = intval($this->wc_pakettikauppa_settings['pickup_points_search_limit']);
     }
 
-    $pickup_point_data = $this->wc_pakettikauppa_client->searchPickupPoints( trim( $postcode ), trim( $street_address ), trim( $country ), $service_provider, $pickup_point_limit );
+    $pickup_point_data = $this->wc_pakettikauppa_client->searchPickupPoints(trim($postcode), trim($street_address), trim($country), $service_provider, $pickup_point_limit);
     if ( $pickup_point_data === 'Bad request' ) {
-      throw new Exception( __( 'WC_Pakettikauppa: An error occured when searching pickup points.', 'wc-pakettikauppa' ) );
+      throw new Exception(__('WC_Pakettikauppa: An error occured when searching pickup points.', 'wc-pakettikauppa'));
     }
 
     return $pickup_point_data;
@@ -492,7 +492,7 @@ class WC_Pakettikauppa_Shipment {
   public function service_title( $service_code ) {
 
     $services = $this->services();
-    if ( isset( $services[ $service_code ] ) ) {
+    if ( isset($services[ $service_code ]) ) {
       return $services[ $service_code ];
     }
 
@@ -518,10 +518,10 @@ class WC_Pakettikauppa_Shipment {
     }
 
     foreach ( $all_shipping_methods as $shipping_method ) {
-      $services[ strval($shipping_method->shipping_method_code) ] = sprintf( '%1$s: %2$s', $shipping_method->service_provider, $shipping_method->name );
+      $services[ strval($shipping_method->shipping_method_code) ] = sprintf('%1$s: %2$s', $shipping_method->service_provider, $shipping_method->name);
     }
 
-    ksort( $services );
+    ksort($services);
 
     return $services;
   }
@@ -535,7 +535,7 @@ class WC_Pakettikauppa_Shipment {
 
     $additional_services = array();
     foreach ( $all_shipping_methods as $shipping_method ) {
-      $additional_services[ strval( $shipping_method->shipping_method_code ) ] = $shipping_method->additional_services;
+      $additional_services[ strval($shipping_method->shipping_method_code) ] = $shipping_method->additional_services;
     }
 
     return $additional_services;
@@ -552,17 +552,17 @@ class WC_Pakettikauppa_Shipment {
     $transient_name = 'wc_pakettikauppa_shipping_methods';
     $transient_time = 86400; // 24 hours
 
-    $all_shipping_methods = get_transient( $transient_name );
+    $all_shipping_methods = get_transient($transient_name);
 
-    if ( empty( $all_shipping_methods ) ) {
-      $all_shipping_methods = json_decode( $this->wc_pakettikauppa_client->listShippingMethods() );
+    if ( empty($all_shipping_methods) ) {
+      $all_shipping_methods = json_decode($this->wc_pakettikauppa_client->listShippingMethods());
 
-      if ( ! empty( $all_shipping_methods ) ) {
-        set_transient( $transient_name, $all_shipping_methods, $transient_time );
+      if ( ! empty($all_shipping_methods) ) {
+        set_transient($transient_name, $all_shipping_methods, $transient_time);
       }
     }
 
-    if ( empty( $all_shipping_methods ) ) {
+    if ( empty($all_shipping_methods) ) {
       return null;
     }
 

--- a/includes/class-wc-pakettikauppa-shipping-method.php
+++ b/includes/class-wc-pakettikauppa-shipping-method.php
@@ -1,12 +1,12 @@
 <?php
 
 // Prevent direct access to the script
-if ( ! defined( 'ABSPATH' ) ) {
+if ( ! defined('ABSPATH') ) {
   exit;
 }
 
-require_once plugin_dir_path( __FILE__ ) . '/class-wc-pakettikauppa.php';
-require_once plugin_dir_path( __FILE__ ) . '/class-wc-pakettikauppa-shipment.php';
+require_once plugin_dir_path(__FILE__) . '/class-wc-pakettikauppa.php';
+require_once plugin_dir_path(__FILE__) . '/class-wc-pakettikauppa-shipment.php';
 
 /**
  * Pakettikauppa_Shipping_Method Class
@@ -19,7 +19,7 @@ require_once plugin_dir_path( __FILE__ ) . '/class-wc-pakettikauppa-shipment.php
  */
 function wc_pakettikauppa_shipping_method_init() {
 
-  if ( ! class_exists( 'WC_Pakettikauppa_Shipping_Method' ) ) {
+  if ( ! class_exists('WC_Pakettikauppa_Shipping_Method') ) {
 
     class WC_Pakettikauppa_Shipping_Method extends WC_Shipping_Method {
       /**
@@ -42,13 +42,13 @@ function wc_pakettikauppa_shipping_method_init() {
        * @return void
        */
       public function __construct( $instance_id = 0 ) {
-        parent::__construct( $instance_id );
+        parent::__construct($instance_id);
 
         $this->id = 'pakettikauppa_shipping_method'; // ID for your shipping method. Should be unique.
 
         $this->method_title = 'Pakettikauppa';
 
-        $this->method_description = __( 'Edit to select shipping company and shipping prices.', 'wc-pakettikauppa' ); // Description shown in admin
+        $this->method_description = __('Edit to select shipping company and shipping prices.', 'wc-pakettikauppa'); // Description shown in admin
         //        $this->method_description = __( 'All shipping methods with one contract. For more information visit <a href="https://www.pakettikauppa.fi/">Pakettikauppa</a>.', 'wc-pakettikauppa' ); // Description shown in admin
 
         // Make Pakettikauppa API accessible via WC_Pakettikauppa_Shipment
@@ -65,14 +65,17 @@ function wc_pakettikauppa_shipping_method_init() {
         $this->init();
 
         // Save settings in admin if you have any defined
-        add_action( 'woocommerce_update_options_shipping_' . $this->id, array(
-          $this,
-          'process_admin_options',
-        ) );
+        add_action(
+          'woocommerce_update_options_shipping_' . $this->id,
+          array(
+            $this,
+            'process_admin_options',
+          )
+        );
 
         if ( ! empty($this->get_instance_option('shipping_method')) ) {
           /* translators: %s: shipping method */
-          $this->method_description = sprintf(__( 'Selected shipping method: %s', 'wc-pakettikauppa'), $this->wc_pakettikauppa_shipment->service_title($this->get_instance_option('shipping_method')));
+          $this->method_description = sprintf(__('Selected shipping method: %s', 'wc-pakettikauppa'), $this->wc_pakettikauppa_shipment->service_title($this->get_instance_option('shipping_method')));
         }
 
       }
@@ -83,20 +86,20 @@ function wc_pakettikauppa_shipping_method_init() {
       public function init() {
         $this->instance_form_fields = $this->my_instance_form_fields();
         $this->form_fields          = $this->my_global_form_fields();
-        $this->title                = $this->get_option( 'title' );
+        $this->title                = $this->get_option('title');
       }
 
       public function validate_pickuppoints_field( $key, $value ) {
-        $values = wp_json_encode( $value );
+        $values = wp_json_encode($value);
         return $values;
       }
 
       public function generate_pickuppoints_html( $key, $value ) {
-        $field_key = $this->get_field_key( $key );
-        if ( $this->get_option( $key ) !== '' ) {
-          $values = $this->get_option( $key );
-          if ( is_string( $values ) ) {
-            $values = json_decode( $this->get_option( $key ), true );
+        $field_key = $this->get_field_key($key);
+        if ( $this->get_option($key) !== '' ) {
+          $values = $this->get_option($key);
+          if ( is_string($values) ) {
+            $values = json_decode($this->get_option($key), true);
           }
         } else {
           $values = array();
@@ -127,32 +130,32 @@ function wc_pakettikauppa_shipping_method_init() {
             }
         </script>
           <tr>
-              <th colspan="2" class="titledesc" scope="row"><?php echo esc_html( $value['title'] ); ?></th>
+              <th colspan="2" class="titledesc" scope="row"><?php echo esc_html($value['title']); ?></th>
           </tr>
           <tr>
               <td colspan="2">
-                    <?php foreach ( WC_Shipping_Zones::get_zones( 'admin' ) as $zone_index => $zone ) : ?>
+                    <?php foreach ( WC_Shipping_Zones::get_zones('admin') as $zone_index => $zone ) : ?>
                         <h2><?php echo $zone['zone_name']; ?></h2>
                       <?php foreach ( $zone['shipping_methods'] as $method_id => $shipping_method ) : ?>
                         <?php if ( $shipping_method->enabled === 'yes' && $shipping_method->id !== 'pakettikauppa_shipping_method' && $shipping_method->id !== 'local_pickup' ) : ?>
                           <?php
                           $selected_service = null;
-                          if ( ! empty( $values[ $method_id ]['service'] ) ) {
+                          if ( ! empty($values[ $method_id ]['service']) ) {
                               $selected_service = $values[ $method_id ]['service'];
                           }
-                          if ( empty( $selected_service ) ) {
+                          if ( empty($selected_service) ) {
                               $selected_service = '__PICKUPPOINTS__';
                           }
                           ?>
                             <table style="border-collapse: collapse;" border="0">
                                 <th><?php echo $shipping_method->title; ?></th>
                                 <td style="vertical-align: top;">
-                                    <select id="<?php echo $method_id; ?>-select" name="<?php echo esc_html( $field_key ) . '[' . esc_attr( $method_id ) . '][service]'; ?>" onchange="pkChangeOptions(this, '<?php echo $method_id; ?>');">
-                                        <option value="__NULL__"><?php esc_html_e( 'No shipping', 'wc-pakettikauppa'); ?></option>
-                                        <option value="__PICKUPPOINTS__" <?php echo ( $selected_service === '__PICKUPPOINTS__' ? 'selected' : '' ); ?>>Noutopisteet</option>
+                                    <select id="<?php echo $method_id; ?>-select" name="<?php echo esc_html($field_key) . '[' . esc_attr($method_id) . '][service]'; ?>" onchange="pkChangeOptions(this, '<?php echo $method_id; ?>');">
+                                        <option value="__NULL__"><?php esc_html_e('No shipping', 'wc-pakettikauppa'); ?></option>
+                                        <option value="__PICKUPPOINTS__" <?php echo ($selected_service === '__PICKUPPOINTS__' ? 'selected' : ''); ?>>Noutopisteet</option>
                                         <?php foreach ( $all_shipping_methods as $service_id => $service_name ) : ?>
-                                          <?php if ( ! in_array ( $service_id, array( '2103', '80010', '90080' ) ) ) : ?>
-                                            <option value="<?php echo $service_id; ?>" <?php echo ( strval( $selected_service ) === strval( $service_id ) ? 'selected' : '' ); ?>><?php echo $service_name; ?></option>
+                                          <?php if ( ! in_array($service_id, array( '2103', '80010', '90080' )) ) : ?>
+                                            <option value="<?php echo $service_id; ?>" <?php echo (strval($selected_service) === strval($service_id) ? 'selected' : ''); ?>><?php echo $service_name; ?></option>
                                           <?php endif; ?>
                                         <?php endforeach; ?>
                                     </select>
@@ -170,12 +173,12 @@ function wc_pakettikauppa_shipping_method_init() {
                                   ?>
                                   <?php foreach ( $methods as $method_code => $method_name ) : ?>
                                       <input type="hidden"
-                                             name="<?php echo esc_html( $field_key ) . '[' . esc_attr( $method_id ) . '][' . $method_code . '][active]'; ?>"
+                                             name="<?php echo esc_html($field_key) . '[' . esc_attr($method_id) . '][' . $method_code . '][active]'; ?>"
                                              value="no">
                                       <p>
                                           <input type="checkbox"
-                                                 name="<?php echo esc_html( $field_key ) . '[' . esc_attr( $method_id ) . '][' . $method_code . '][active]'; ?>"
-                                                 value="yes" <?php echo ( ! empty( $values[ $method_id ][ $method_code ]['active'] ) && $values[ $method_id ][ $method_code ]['active'] === 'yes' ) ? 'checked' : ''; ?>>
+                                                 name="<?php echo esc_html($field_key) . '[' . esc_attr($method_id) . '][' . $method_code . '][active]'; ?>"
+                                                 value="yes" <?php echo (! empty($values[ $method_id ][ $method_code ]['active']) && $values[ $method_id ][ $method_code ]['active'] === 'yes') ? 'checked' : ''; ?>>
                                         <?php echo $method_name; ?>
                                       </p>
                                   <?php endforeach; ?>
@@ -185,14 +188,14 @@ function wc_pakettikauppa_shipping_method_init() {
                                     <?php foreach ( $all_additional_services as $method_code => $additional_services ) : ?>
                                     <div class="pk-services-<?php echo $method_id; ?>" style='display: none;' id="<?php echo $method_id; ?>-<?php echo $method_code; ?>-services">
                                       <?php foreach ( $additional_services as $additional_service ) : ?>
-                                        <?php if ( empty( $additional_service->specifiers ) || $additional_service->service_code === '3102' ) : ?>
+                                        <?php if ( empty($additional_service->specifiers) || $additional_service->service_code === '3102' ) : ?>
                                         <input type="hidden"
-                                               name="<?php echo esc_html( $field_key ) . '[' . esc_attr( $method_id ) . '][' . esc_attr( $method_code ) . '][additional_services][' . $additional_service->service_code . ']'; ?>"
+                                               name="<?php echo esc_html($field_key) . '[' . esc_attr($method_id) . '][' . esc_attr($method_code) . '][additional_services][' . $additional_service->service_code . ']'; ?>"
                                                value="no">
                                         <p>
                                             <input type="checkbox"
-                                                   name="<?php echo esc_html( $field_key ) . '[' . esc_attr( $method_id ) . '][' . esc_attr( $method_code ) . '][additional_services][' . $additional_service->service_code . ']'; ?>"
-                                                   value="yes" <?php echo ( ! empty( $values[ $method_id ][ $method_code ]['additional_services'][ $additional_service->service_code ] ) && $values[ $method_id ][ $method_code ]['additional_services'][ $additional_service->service_code ] === 'yes' ) ? 'checked' : ''; ?>>
+                                                   name="<?php echo esc_html($field_key) . '[' . esc_attr($method_id) . '][' . esc_attr($method_code) . '][additional_services][' . $additional_service->service_code . ']'; ?>"
+                                                   value="yes" <?php echo (! empty($values[ $method_id ][ $method_code ]['additional_services'][ $additional_service->service_code ]) && $values[ $method_id ][ $method_code ]['additional_services'][ $additional_service->service_code ] === 'yes') ? 'checked' : ''; ?>>
                                           <?php echo $additional_service->name; ?>
                                         </p>
                                         <?php endif; ?>
@@ -218,7 +221,7 @@ function wc_pakettikauppa_shipping_method_init() {
        * Initialize form fields
        */
       private function my_instance_form_fields() {
-        $all_shipping_methods = array( '' => __( 'Select one shipping method', 'wc-pakettikauppa' ) );
+        $all_shipping_methods = array( '' => __('Select one shipping method', 'wc-pakettikauppa') );
 
         $all_services = $this->wc_pakettikauppa_shipment->services();
 
@@ -226,12 +229,12 @@ function wc_pakettikauppa_shipping_method_init() {
           $all_shipping_methods[ $key ] = $value;
         }
 
-        if ( empty( $all_services ) ) {
+        if ( empty($all_services) ) {
           $fields = array(
             'title' => array(
-              'title'       => __( 'Title', 'woocommerce' ),
+              'title'       => __('Title', 'woocommerce'),
               'type'        => 'text',
-              'description' => __( 'Can not connect to Pakettikauppa server - please check Pakettikauppa API credentials, servers error log and firewall settings.', 'wc-pakettikauppa' ),
+              'description' => __('Can not connect to Pakettikauppa server - please check Pakettikauppa API credentials, servers error log and firewall settings.', 'wc-pakettikauppa'),
               'default'     => 'Pakettikauppa',
               'desc_tip'    => true,
             ),
@@ -242,100 +245,100 @@ function wc_pakettikauppa_shipping_method_init() {
 
         $fields = array(
           'title'           => array(
-            'title'       => __( 'Title', 'woocommerce' ),
+            'title'       => __('Title', 'woocommerce'),
             'type'        => 'text',
-            'description' => __( 'This controls the title which the user sees during checkout.', 'woocommerce' ),
+            'description' => __('This controls the title which the user sees during checkout.', 'woocommerce'),
             'default'     => 'Pakettikauppa',
             'desc_tip'    => true,
           ),
             /* Start new section */
           array(
-            'title' => __( 'Shipping methods', 'wc-pakettikauppa' ),
+            'title' => __('Shipping methods', 'wc-pakettikauppa'),
             'type'  => 'title',
           ),
 
           'shipping_method' => array(
-            'title'   => __( 'Shipping method', 'wc-pakettikauppa' ),
+            'title'   => __('Shipping method', 'wc-pakettikauppa'),
             'type'    => 'select',
             'options' => $all_shipping_methods,
           ),
 
           array(
-            'title'       => __( 'Shipping class costs', 'woocommerce' ),
+            'title'       => __('Shipping class costs', 'woocommerce'),
             'type'        => 'title',
             'default'     => '',
                 /* translators: %s: URL for link. */
-            'description' => sprintf( __( 'These costs can optionally be added based on the <a href="%s">product shipping class</a>.', 'woocommerce' ), admin_url( 'admin.php?page=wc-settings&tab=shipping&section=classes' ) ),
+            'description' => sprintf(__('These costs can optionally be added based on the <a href="%s">product shipping class</a>.', 'woocommerce'), admin_url('admin.php?page=wc-settings&tab=shipping&section=classes')),
           ),
         );
 
         $shipping_classes = WC()->shipping->get_shipping_classes();
 
-        if ( ! empty( $shipping_classes ) ) {
+        if ( ! empty($shipping_classes) ) {
           foreach ( $shipping_classes as $shipping_class ) {
-            if ( ! isset( $shipping_class->term_id ) ) {
+            if ( ! isset($shipping_class->term_id) ) {
               continue;
             }
 
             $fields[] = array(
               /* translators: %s: shipping class cost */
-              'title'   => sprintf( __( '"%s" shipping class cost', 'woocommerce' ), esc_html( $shipping_class->name ) ),
+              'title'   => sprintf(__('"%s" shipping class cost', 'woocommerce'), esc_html($shipping_class->name)),
               'type'    => 'title',
               'default' => '',
             );
 
             $fields[ 'class_cost_' . $shipping_class->term_id . '_price' ] = array(
             /* translators: %s: shipping class name */
-              'title'       => __( 'Price (vat included)', 'wc-pakettikauppa' ),
+              'title'       => __('Price (vat included)', 'wc-pakettikauppa'),
               'type'        => 'number',
               'default'     => null,
-              'placeholder' => __( 'N/A', 'woocommerce' ),
-              'description' => __( 'Shipping cost', 'wc-pakettikauppa' ),
+              'placeholder' => __('N/A', 'woocommerce'),
+              'description' => __('Shipping cost', 'wc-pakettikauppa'),
               'desc_tip'    => true,
             );
 
             $fields[ 'class_cost_' . $shipping_class->term_id . '_price_free' ] = array(
-              'title'       => __( 'Free shipping tier', 'wc-pakettikauppa' ),
+              'title'       => __('Free shipping tier', 'wc-pakettikauppa'),
               'type'        => 'number',
               'default'     => null,
-              'description' => __( 'After which amount shipping is free.', 'wc-pakettikauppa' ),
+              'description' => __('After which amount shipping is free.', 'wc-pakettikauppa'),
               'desc_tip'    => true,
             );
           }
 
           $fields['type'] = array(
-            'title'   => __( 'Calculation type', 'woocommerce' ),
+            'title'   => __('Calculation type', 'woocommerce'),
             'type'    => 'select',
             'class'   => 'wc-enhanced-select',
             'default' => 'class',
             'options' => array(
-              'class' => __( 'Per class: Charge shipping for each shipping class individually', 'woocommerce' ),
-              'order' => __( 'Per order: Charge shipping for the most expensive shipping class', 'woocommerce' ),
+              'class' => __('Per class: Charge shipping for each shipping class individually', 'woocommerce'),
+              'order' => __('Per order: Charge shipping for the most expensive shipping class', 'woocommerce'),
             ),
           );
 
         }
 
         $fields[] = array(
-          'title'   => __( 'Default shipping class cost', 'wc-pakettikauppa' ),
+          'title'   => __('Default shipping class cost', 'wc-pakettikauppa'),
           'type'    => 'title',
           'default' => '',
         );
 
         $fields['price'] = array(
-          'title'       => __( 'No shipping class cost (vat included)', 'wc-pakettikauppa' ),
+          'title'       => __('No shipping class cost (vat included)', 'wc-pakettikauppa'),
           'type'        => 'number',
           'default'     => $this->fee,
-          'placeholder' => __( 'N/A', 'woocommerce' ),
-          'description' => __( 'Shipping cost  (vat included)', 'wc-pakettikauppa' ),
+          'placeholder' => __('N/A', 'woocommerce'),
+          'description' => __('Shipping cost  (vat included)', 'wc-pakettikauppa'),
           'desc_tip'    => true,
         );
 
         $fields['price_free'] = array(
-          'title'       => __( 'Free shipping tier', 'wc-pakettikauppa' ),
+          'title'       => __('Free shipping tier', 'wc-pakettikauppa'),
           'type'        => 'number',
           'default'     => '',
-          'description' => __( 'After which amount shipping is free.', 'wc-pakettikauppa' ),
+          'description' => __('After which amount shipping is free.', 'wc-pakettikauppa'),
           'desc_tip'    => true,
         );
 
@@ -345,116 +348,116 @@ function wc_pakettikauppa_shipping_method_init() {
       private function my_global_form_fields() {
         return array(
           'mode'                       => array(
-            'title'   => __( 'Mode', 'wc-pakettikauppa' ),
+            'title'   => __('Mode', 'wc-pakettikauppa'),
             'type'    => 'select',
             'default' => 'test',
             'options' => array(
-              'test'       => __( 'Testing environment', 'wc-pakettikauppa' ),
-              'production' => __( 'Production environment', 'wc-pakettikauppa' ),
+              'test'       => __('Testing environment', 'wc-pakettikauppa'),
+              'production' => __('Production environment', 'wc-pakettikauppa'),
             ),
           ),
 
           'account_number'             => array(
-            'title'    => __( 'API key', 'wc-pakettikauppa' ),
-            'desc'     => __( 'API key provided by Pakettikauppa', 'wc-pakettikauppa' ),
+            'title'    => __('API key', 'wc-pakettikauppa'),
+            'desc'     => __('API key provided by Pakettikauppa', 'wc-pakettikauppa'),
             'type'     => 'text',
             'default'  => '',
             'desc_tip' => true,
           ),
 
           'secret_key'                 => array(
-            'title'    => __( 'API secret', 'wc-pakettikauppa' ),
-            'desc'     => __( 'API Secret provided by Pakettikauppa', 'wc-pakettikauppa' ),
+            'title'    => __('API secret', 'wc-pakettikauppa'),
+            'desc'     => __('API Secret provided by Pakettikauppa', 'wc-pakettikauppa'),
             'type'     => 'text',
             'default'  => '',
             'desc_tip' => true,
           ),
 
           'pickup_points'              => array(
-            'title' => __( 'Show pickup points for non-Pakettikauppa shipments', 'wc-pakettikauppa' ),
+            'title' => __('Show pickup points for non-Pakettikauppa shipments', 'wc-pakettikauppa'),
             'type'  => 'pickuppoints',
           ),
 
           array(
-            'title'       => __( 'Shipping settings', 'wc-pakettikauppa' ),
+            'title'       => __('Shipping settings', 'wc-pakettikauppa'),
             'type'        => 'title',
             /* translators: %s: url to documentation */
-            'description' => sprintf(__( 'You can activate new shipping method to checkout in <b>WooCommerce > Settings > Shipping > Shipping zones</b>. For more information, see <a target="_blank" href="%1$s">%1$s</a>', 'wc-pakettikauppa'), 'https://docs.woocommerce.com/document/setting-up-shipping-zones/'),
+            'description' => sprintf(__('You can activate new shipping method to checkout in <b>WooCommerce > Settings > Shipping > Shipping zones</b>. For more information, see <a target="_blank" href="%1$s">%1$s</a>', 'wc-pakettikauppa'), 'https://docs.woocommerce.com/document/setting-up-shipping-zones/'),
 
           ),
 
           'add_tracking_to_email'      => array(
-            'title'   => __( 'Add tracking link to the order completed email', 'wc-pakettikauppa' ),
+            'title'   => __('Add tracking link to the order completed email', 'wc-pakettikauppa'),
             'type'    => 'checkbox',
             'default' => 'no',
           ),
 
           'add_pickup_point_to_email'      => array(
-            'title'   => __( 'Add selected pickup point information to the order completed email', 'wc-pakettikauppa' ),
+            'title'   => __('Add selected pickup point information to the order completed email', 'wc-pakettikauppa'),
             'type'    => 'checkbox',
             'default' => 'no',
           ),
 
           'pickup_points_search_limit' => array(
-            'title'       => __( 'Pickup point search limit', 'wc-pakettikauppa' ),
+            'title'       => __('Pickup point search limit', 'wc-pakettikauppa'),
             'type'        => 'number',
             'default'     => 5,
-            'description' => __( 'Limit the amount of nearest pickup points shown.', 'wc-pakettikauppa' ),
+            'description' => __('Limit the amount of nearest pickup points shown.', 'wc-pakettikauppa'),
             'desc_tip'    => true,
           ),
           'pickup_point_list_type'     => array(
-            'title'   => __( 'Show pickup points as', 'wc-pakettikauppa' ),
+            'title'   => __('Show pickup points as', 'wc-pakettikauppa'),
             'type'    => 'select',
             'default' => 'menu',
             'options' => array(
-              'menu'  => __( 'Menu', 'wc-pakettikauppa' ),
-              'list'  => __( 'List', 'wc-pakettikauppa' ),
+              'menu'  => __('Menu', 'wc-pakettikauppa'),
+              'list'  => __('List', 'wc-pakettikauppa'),
             ),
           ),
           array(
-            'title' => __( 'Store owner information', 'wc-pakettikauppa' ),
+            'title' => __('Store owner information', 'wc-pakettikauppa'),
             'type'  => 'title',
           ),
 
           'sender_name'                => array(
-            'title'   => __( 'Sender name', 'wc-pakettikauppa' ),
+            'title'   => __('Sender name', 'wc-pakettikauppa'),
             'type'    => 'text',
             'default' => '',
           ),
 
           'sender_address'             => array(
-            'title'   => __( 'Sender address', 'wc-pakettikauppa' ),
+            'title'   => __('Sender address', 'wc-pakettikauppa'),
             'type'    => 'text',
             'default' => '',
           ),
 
           'sender_postal_code'         => array(
-            'title'   => __( 'Sender postal code', 'wc-pakettikauppa' ),
+            'title'   => __('Sender postal code', 'wc-pakettikauppa'),
             'type'    => 'text',
             'default' => '',
           ),
 
           'sender_city'                => array(
-            'title'   => __( 'Sender city', 'wc-pakettikauppa' ),
+            'title'   => __('Sender city', 'wc-pakettikauppa'),
             'type'    => 'text',
             'default' => '',
           ),
           'info_code'                  => array(
-            'title'   => __( 'Info-code for shipments', 'wc-pakettikauppa' ),
+            'title'   => __('Info-code for shipments', 'wc-pakettikauppa'),
             'type'    => 'text',
             'default' => '',
           ),
           array(
-            'title' => __( 'Cash on Delivery (COD) Settings', 'wc-pakettikauppa' ),
+            'title' => __('Cash on Delivery (COD) Settings', 'wc-pakettikauppa'),
             'type'  => 'title',
           ),
           'cod_iban'                   => array(
-            'title'   => __( 'Bank account number for Cash on Delivery (IBAN)', 'wc-pakettikauppa' ),
+            'title'   => __('Bank account number for Cash on Delivery (IBAN)', 'wc-pakettikauppa'),
             'type'    => 'text',
             'default' => '',
           ),
           'cod_bic'                    => array(
-            'title'   => __( 'BIC code for Cash on Delivery', 'wc-pakettikauppa' ),
+            'title'   => __('BIC code for Cash on Delivery', 'wc-pakettikauppa'),
             'type'    => 'text',
             'default' => '',
           ),
@@ -485,14 +488,14 @@ function wc_pakettikauppa_shipping_method_init() {
           $cost_item = $shipping_cost * $item['line_total'] / $cart_total;
 
           if ( $cart[ $cost_key ]['data'] !== null ) {
-            $tax_obj = WC_Tax::get_shipping_tax_rates( $cart[ $cost_key ]['data']->get_tax_class() );
+            $tax_obj = WC_Tax::get_shipping_tax_rates($cart[ $cost_key ]['data']->get_tax_class());
 
             foreach ( $tax_obj as $key => $value ) {
-              if ( ! isset( $taxes[ $key ] ) ) {
+              if ( ! isset($taxes[ $key ]) ) {
                 $taxes[ $key ] = 0.0;
               }
 
-              $taxes[ $key ] += round( $cost_item - $cost_item / ( 1 + $value['rate'] / 100.0 ), 2 );
+              $taxes[ $key ] += round($cost_item - $cost_item / (1 + $value['rate'] / 100.0), 2);
             }
           }
         }
@@ -521,7 +524,7 @@ function wc_pakettikauppa_shipping_method_init() {
           if ( $values['data']->needs_shipping() ) {
             $found_class = $values['data']->get_shipping_class();
 
-            if ( ! isset( $found_shipping_classes[ $found_class ] ) ) {
+            if ( ! isset($found_shipping_classes[ $found_class ]) ) {
               $found_shipping_classes[ $found_class ] = array();
             }
 
@@ -537,13 +540,13 @@ function wc_pakettikauppa_shipping_method_init() {
           $key_base = "class_cost_{$key_base}_";
         }
 
-        $shipping_cost = $this->get_option( $key_base . 'price', - 1 );
+        $shipping_cost = $this->get_option($key_base . 'price', - 1);
 
         if ( $shipping_cost < 0 ) {
           $shipping_cost = null;
         }
 
-        if ( $this->get_option( $key_base . 'price_free', 0 ) <= $cart_total && $this->get_option( $key_base . 'price_free', 0 ) > 0 ) {
+        if ( $this->get_option($key_base . 'price_free', 0) <= $cart_total && $this->get_option($key_base . 'price_free', 0) > 0 ) {
           $shipping_cost = 0;
         }
 
@@ -567,13 +570,13 @@ function wc_pakettikauppa_shipping_method_init() {
 
         $cart_total = $cart->get_cart_contents_total() + $cart->get_cart_contents_tax();
 
-        $service_code = $this->get_option( 'shipping_method' );
-        $service_title = $this->get_option( 'title' );
+        $service_code = $this->get_option('shipping_method');
+        $service_title = $this->get_option('title');
 
         $all_applied_coupons = $cart->get_applied_coupons();
         if ( $all_applied_coupons ) {
           foreach ( $all_applied_coupons as $coupon_code ) {
-            $this_coupon = new WC_Coupon( $coupon_code );
+            $this_coupon = new WC_Coupon($coupon_code);
             if ( $this_coupon->get_free_shipping() ) {
 
               $this->add_rate(
@@ -594,21 +597,21 @@ function wc_pakettikauppa_shipping_method_init() {
 
         $shipping_classes = WC()->shipping->get_shipping_classes();
 
-        if ( ! empty( $shipping_classes ) ) {
-          $found_shipping_classes = $this->find_shipping_classes( $package );
+        if ( ! empty($shipping_classes) ) {
+          $found_shipping_classes = $this->find_shipping_classes($package);
           $highest_class_cost     = 0;
 
           foreach ( $found_shipping_classes as $shipping_class => $products ) {
-            $shipping_zone = get_term_by( 'slug', $shipping_class, 'product_shipping_class' );
+            $shipping_zone = get_term_by('slug', $shipping_class, 'product_shipping_class');
 
-            $class_shipping_cost = $this->get_shipping_cost( $cart_total, $shipping_zone->term_id );
+            $class_shipping_cost = $this->get_shipping_cost($cart_total, $shipping_zone->term_id);
 
             if ( $class_shipping_cost !== null ) {
               if ( $shipping_cost === null ) {
                 $shipping_cost = 0;
               }
 
-              if ( 'class' === $this->get_option( 'type' ) ) {
+              if ( 'class' === $this->get_option('type') ) {
                 $shipping_cost += $class_shipping_cost;
               } else {
                 $highest_class_cost = $class_shipping_cost > $highest_class_cost ? $class_shipping_cost : $highest_class_cost;
@@ -616,33 +619,33 @@ function wc_pakettikauppa_shipping_method_init() {
             }
           }
 
-          if ( 'order' === $this->get_option( 'type' ) && $highest_class_cost ) {
+          if ( 'order' === $this->get_option('type') && $highest_class_cost ) {
             $shipping_cost += $highest_class_cost;
           }
         }
 
         if ( $shipping_cost === null ) {
-          $shipping_cost = $this->get_shipping_cost( $cart_total );
+          $shipping_cost = $this->get_shipping_cost($cart_total);
         }
 
-        $taxes = $this->calculate_shipping_tax( $shipping_cost );
+        $taxes = $this->calculate_shipping_tax($shipping_cost);
 
         $shipping_cost = $shipping_cost - $taxes['total'];
 
         $this->add_rate(
-            array(
-              'meta_data' => [ 'service_code' => $service_code ],
-              'label'     => $service_title,
-              'cost'      => (string) $shipping_cost,
-              'taxes'     => $taxes['taxes'],
-              'package'   => $package,
-            )
+          array(
+            'meta_data' => [ 'service_code' => $service_code ],
+            'label'     => $service_title,
+            'cost'      => (string) $shipping_cost,
+            'taxes'     => $taxes['taxes'],
+            'package'   => $package,
+          )
         );
       }
 
       public function process_admin_options() {
         if ( ! $this->instance_id ) {
-          delete_transient( 'wc_pakettikauppa_shipping_methods' );
+          delete_transient('wc_pakettikauppa_shipping_methods');
         }
 
         return parent::process_admin_options();
@@ -651,7 +654,7 @@ function wc_pakettikauppa_shipping_method_init() {
   }
 }
 
-add_action( 'woocommerce_shipping_init', 'wc_pakettikauppa_shipping_method_init' );
+add_action('woocommerce_shipping_init', 'wc_pakettikauppa_shipping_method_init');
 
 function add_wc_pakettikauppa_shipping_method( $methods ) {
   $methods['pakettikauppa_shipping_method'] = 'WC_Pakettikauppa_Shipping_Method';
@@ -659,4 +662,4 @@ function add_wc_pakettikauppa_shipping_method( $methods ) {
   return $methods;
 }
 
-add_filter( 'woocommerce_shipping_methods', 'add_wc_pakettikauppa_shipping_method' );
+add_filter('woocommerce_shipping_methods', 'add_wc_pakettikauppa_shipping_method');

--- a/includes/class-wc-pakettikauppa.php
+++ b/includes/class-wc-pakettikauppa.php
@@ -1,7 +1,7 @@
 <?php
 
 // Prevent direct access to this script
-if ( ! defined( 'ABSPATH' ) ) {
+if ( ! defined('ABSPATH') ) {
   exit;
 }
 
@@ -30,17 +30,17 @@ class WC_Pakettikauppa {
   }
 
   public function load() {
-    add_action( 'enqueue_scripts', array( $this, 'enqueue_scripts' ) );
-    add_action( 'woocommerce_review_order_after_shipping', array( $this, 'pickup_point_field_html' ) );
-    add_action( 'woocommerce_order_details_after_order_table', array( $this, 'display_order_data' ) );
-    add_action( 'woocommerce_checkout_update_order_meta', array( $this, 'update_order_meta_pickup_point_field' ) );
-    add_action( 'woocommerce_checkout_process', array( $this, 'validate_checkout_pickup_point' ) );
+    add_action('enqueue_scripts', array( $this, 'enqueue_scripts' ));
+    add_action('woocommerce_review_order_after_shipping', array( $this, 'pickup_point_field_html' ));
+    add_action('woocommerce_order_details_after_order_table', array( $this, 'display_order_data' ));
+    add_action('woocommerce_checkout_update_order_meta', array( $this, 'update_order_meta_pickup_point_field' ));
+    add_action('woocommerce_checkout_process', array( $this, 'validate_checkout_pickup_point' ));
 
     try {
       $this->wc_pakettikauppa_shipment = new WC_Pakettikauppa_Shipment();
       $this->wc_pakettikauppa_shipment->load();
     } catch ( Exception $e ) {
-      $this->add_error( $e->getMessage() );
+      $this->add_error($e->getMessage());
       $this->display_error();
     }
   }
@@ -51,8 +51,8 @@ class WC_Pakettikauppa {
    * @param string $message A message containing details about the error.
    */
   public function add_error( $message ) {
-    if ( ! empty( $message ) ) {
-      array_push( $this->errors, $message );
+    if ( ! empty($message) ) {
+      array_push($this->errors, $message);
     }
   }
 
@@ -60,15 +60,15 @@ class WC_Pakettikauppa {
    * Display error in woocommerce
    */
   public function display_error() {
-    wc_add_notice( __( 'An error occured. Please try again later.', 'wc-pakettikauppa' ), 'error' );
+    wc_add_notice(__('An error occured. Please try again later.', 'wc-pakettikauppa'), 'error');
   }
 
   /**
    * Enqueue frontend-specific styles and scripts.
    */
   public function enqueue_scripts() {
-    wp_enqueue_style( 'wc_pakettikauppa', plugin_dir_url( __FILE__ ) . '../assets/css/wc-pakettikauppa.css', array(), WC_PAKETTIKAUPPA_VERSION );
-    wp_enqueue_script( 'wc_pakettikauppa_js', plugin_dir_url( __FILE__ ) . '../assets/js/wc-pakettikauppa.js', array( 'jquery' ), WC_PAKETTIKAUPPA_VERSION, true);
+    wp_enqueue_style('wc_pakettikauppa', plugin_dir_url(__FILE__) . '../assets/css/wc-pakettikauppa.css', array(), WC_PAKETTIKAUPPA_VERSION);
+    wp_enqueue_script('wc_pakettikauppa_js', plugin_dir_url(__FILE__) . '../assets/js/wc-pakettikauppa.js', array( 'jquery' ), WC_PAKETTIKAUPPA_VERSION, true);
   }
 
   /**
@@ -78,19 +78,19 @@ class WC_Pakettikauppa {
    * @param int $order_id The id of the order to update
    */
   public function update_order_meta_pickup_point_field( $order_id ) {
-    if ( ! empty( $_POST['pakettikauppa_pickup_point'] ) && wp_verify_nonce( sanitize_key( $_POST['woocommerce-process-checkout-nonce'] ), 'woocommerce-process_checkout' ) ) {
-      update_post_meta( $order_id, '_pakettikauppa_pickup_point', sanitize_text_field( $_POST['pakettikauppa_pickup_point'] ) );
+    if ( ! empty($_POST['pakettikauppa_pickup_point']) && wp_verify_nonce(sanitize_key($_POST['woocommerce-process-checkout-nonce']), 'woocommerce-process_checkout') ) {
+      update_post_meta($order_id, '_pakettikauppa_pickup_point', sanitize_text_field($_POST['pakettikauppa_pickup_point']));
       // Find string like '(#6681)'
-      preg_match( '/\(#[0-9]+\)/', $_POST['pakettikauppa_pickup_point'], $matches );
+      preg_match('/\(#[0-9]+\)/', $_POST['pakettikauppa_pickup_point'], $matches);
       // Cut the number out from a string of the form '(#6681)'
-      $pakettikauppa_pickup_point_id = substr( $matches[0], 2, - 1 );
-      update_post_meta( $order_id, '_pakettikauppa_pickup_point_id', $pakettikauppa_pickup_point_id );
+      $pakettikauppa_pickup_point_id = substr($matches[0], 2, - 1);
+      update_post_meta($order_id, '_pakettikauppa_pickup_point_id', $pakettikauppa_pickup_point_id);
 
-      preg_match( '/\(\%[0-9]+\)/', $_POST['pakettikauppa_pickup_point'], $matches );
+      preg_match('/\(\%[0-9]+\)/', $_POST['pakettikauppa_pickup_point'], $matches);
       // Cut the number out from a string of the form '(#6681)'
-      $pakettikauppa_pickup_point_provider_id = substr( $matches[0], 2, - 1 );
+      $pakettikauppa_pickup_point_provider_id = substr($matches[0], 2, - 1);
 
-      update_post_meta( $order_id, '_pakettikauppa_pickup_point_provider_id', $pakettikauppa_pickup_point_provider_id );
+      update_post_meta($order_id, '_pakettikauppa_pickup_point_provider_id', $pakettikauppa_pickup_point_provider_id);
     }
   }
 
@@ -104,12 +104,12 @@ class WC_Pakettikauppa {
   public function pickup_point_field_html() {
     $packages = WC()->shipping()->get_packages();
 
-    $chosen_shipping_id = WC()->session->get( 'chosen_shipping_methods' )[0];
+    $chosen_shipping_id = WC()->session->get('chosen_shipping_methods')[0];
 
     /** @var WC_Shipping_Rate $shipping_rate */
     $shipping_rate = null;
     foreach ( $packages as $package ) {
-      if ( isset ( $package['rates'][ $chosen_shipping_id ] ) ) {
+      if ( isset($package['rates'][ $chosen_shipping_id ]) ) {
         $shipping_rate = $package['rates'][ $chosen_shipping_id ];
       }
     }
@@ -123,18 +123,18 @@ class WC_Pakettikauppa {
 
     $settings = $this->wc_pakettikauppa_shipment->get_settings();
 
-    if ( isset($shipment_meta_data['service_code'] ) ) {
+    if ( isset($shipment_meta_data['service_code']) ) {
       $shipping_method_id = $shipment_meta_data['service_code'];
 
-      if ( $this->wc_pakettikauppa_shipment->service_has_pickup_points( $shipping_method_id ) ) {
-        $shipping_method_providers[] = $this->wc_pakettikauppa_shipment->service_provider( $shipping_method_id );
+      if ( $this->wc_pakettikauppa_shipment->service_has_pickup_points($shipping_method_id) ) {
+        $shipping_method_providers[] = $this->wc_pakettikauppa_shipment->service_provider($shipping_method_id);
       }
     } else {
       $pickup_points = json_decode($settings['pickup_points'], true);
 
-      $temp_array = explode (':', $chosen_shipping_id ); // for php 5.6 compatibility
+      $temp_array = explode(':', $chosen_shipping_id); // for php 5.6 compatibility
 
-      if ( count( $temp_array ) < 2 ) {
+      if ( count($temp_array) < 2 ) {
         // no instance_id available -> return
         return;
       }
@@ -148,8 +148,8 @@ class WC_Pakettikauppa {
         '2711'  => 'Posti International',
       );
 
-      if ( ! empty( $pickup_points[ $instance_id ] ) ) {
-        if ( ! empty( $pickup_points[ $instance_id ]['service'] ) && $pickup_points[ $instance_id ]['service'] === '__PICKUPPOINTS__' ) {
+      if ( ! empty($pickup_points[ $instance_id ]) ) {
+        if ( ! empty($pickup_points[ $instance_id ]['service']) && $pickup_points[ $instance_id ]['service'] === '__PICKUPPOINTS__' ) {
           foreach ( $pickup_points[ $instance_id ] as $shipping_method => $shipping_method_data ) {
             if ( $shipping_method_data['active'] === 'yes' ) {
               $shipping_method_providers[] = $methods[ $shipping_method ];
@@ -160,7 +160,7 @@ class WC_Pakettikauppa {
     }
 
     // Bail out if the shipping method is not one of the pickup point services
-    if ( empty( $shipping_method_providers ) ) {
+    if ( empty($shipping_method_providers) ) {
       return;
     }
 
@@ -168,25 +168,25 @@ class WC_Pakettikauppa {
     $shipping_address  = WC()->customer->get_shipping_address();
     $shipping_country  = WC()->customer->get_shipping_country();
 
-    if ( empty( $shipping_country ) ) {
+    if ( empty($shipping_country) ) {
       $shipping_country = 'FI';
     }
 
     echo '<tr class="shipping-pickup-point">';
-    echo '<th>' . esc_attr__( 'Pickup point', 'wc-pakettikauppa' ) . '</th>';
-    echo '<td data-title="' . esc_attr__( 'Pickup point', 'wc-pakettikauppa' ) . '">';
+    echo '<th>' . esc_attr__('Pickup point', 'wc-pakettikauppa') . '</th>';
+    echo '<td data-title="' . esc_attr__('Pickup point', 'wc-pakettikauppa') . '">';
 
     // Return if the customer has not yet chosen a postcode
-    if ( empty( $shipping_postcode ) ) {
+    if ( empty($shipping_postcode) ) {
       echo '<p>';
-      esc_attr_e( 'Insert your shipping details to view nearby pickup points', 'wc-pakettikauppa' );
+      esc_attr_e('Insert your shipping details to view nearby pickup points', 'wc-pakettikauppa');
       echo '</p>';
-    } elseif ( ! is_numeric( $shipping_postcode ) ) {
+    } elseif ( ! is_numeric($shipping_postcode) ) {
       echo '<p>';
       printf(
         /* translators: %s: Postcode */
-        esc_attr__( 'Invalid postcode "%1$s". Please check your address information.', 'wc-pakettikauppa' ),
-        esc_attr( $shipping_postcode )
+        esc_attr__('Invalid postcode "%1$s". Please check your address information.', 'wc-pakettikauppa'),
+        esc_attr($shipping_postcode)
       );
       echo '</p>';
     } else {
@@ -195,16 +195,16 @@ class WC_Pakettikauppa {
         $options_array = $this->fetch_pickup_point_options($shipping_postcode, $shipping_address, $shipping_country, implode(',', $shipping_method_providers));
       } catch ( Exception $e ) {
         $options_array = false;
-        $this->add_error( $e->getMessage() );
+        $this->add_error($e->getMessage());
         $this->display_error();
       }
 
       if ( $options_array !== false ) {
 
         printf(
-        /* translators: %s: Postcode */
-          esc_html__( 'Choose one of the pickup points close to your postcode %1$s below:', 'wc-pakettikauppa' ),
-          '<span class="shipping_postcode_for_pickup">' . esc_attr( $shipping_postcode ) . '</span>'
+          /* translators: %s: Postcode */
+          esc_html__('Choose one of the pickup points close to your postcode %1$s below:', 'wc-pakettikauppa'),
+          '<span class="shipping_postcode_for_pickup">' . esc_attr($shipping_postcode) . '</span>'
         );
 
         $list_type = 'select';
@@ -212,7 +212,7 @@ class WC_Pakettikauppa {
         if ( $settings['pickup_point_list_type'] === 'list' ) {
           $list_type = 'radio';
 
-          array_splice( $options_array, 0, 1 );
+          array_splice($options_array, 0, 1);
         }
 
         woocommerce_form_field(
@@ -231,14 +231,14 @@ class WC_Pakettikauppa {
   }
 
   private function fetch_pickup_point_options( $shipping_postcode, $shipping_address, $shipping_country, $shipping_method_provider ) {
-    $pickup_point_data = $this->wc_pakettikauppa_shipment->get_pickup_points( $shipping_postcode, $shipping_address, $shipping_country, $shipping_method_provider );
+    $pickup_point_data = $this->wc_pakettikauppa_shipment->get_pickup_points($shipping_postcode, $shipping_address, $shipping_country, $shipping_method_provider);
 
     return $this->process_pickup_points_to_option_array($pickup_point_data);
   }
 
   private function process_pickup_points_to_option_array( $pickup_point_data ) {
-    $pickup_points = json_decode( $pickup_point_data );
-    $options_array = array( '__NULL__' => '- ' . __( 'Select a pickup point', 'wc-pakettikauppa' ) . ' -' );
+    $pickup_points = json_decode($pickup_point_data);
+    $options_array = array( '__NULL__' => '- ' . __('Select a pickup point', 'wc-pakettikauppa') . ' -' );
 
     $methods = array(
       'Posti'               => '2103',
@@ -262,21 +262,21 @@ class WC_Pakettikauppa {
    * @param WC_Order $order the order that was placed
    */
   public function display_order_data( $order ) {
-    $pickup_point = $order->get_meta( '_pakettikauppa_pickup_point' );
+    $pickup_point = $order->get_meta('_pakettikauppa_pickup_point');
 
-    if ( ! empty( $pickup_point ) ) {
-      echo '<h2>' . esc_attr__( 'Pickup point', 'wc-pakettikauppa' ) . '</h2>';
-      echo '<p>' . esc_attr( $pickup_point ) . '</p>';
+    if ( ! empty($pickup_point) ) {
+      echo '<h2>' . esc_attr__('Pickup point', 'wc-pakettikauppa') . '</h2>';
+      echo '<p>' . esc_attr($pickup_point) . '</p>';
     }
   }
 
   public function validate_checkout_pickup_point() {
-    if ( ! wp_verify_nonce( sanitize_key( $_POST['woocommerce-process-checkout-nonce'] ), 'woocommerce-process_checkout' ) ) {
+    if ( ! wp_verify_nonce(sanitize_key($_POST['woocommerce-process-checkout-nonce']), 'woocommerce-process_checkout') ) {
       return;
     }
 
     if ( $_POST['pakettikauppa_pickup_point'] === '__NULL__' ) {
-      wc_add_notice( __( 'Please choose a pickup point.', 'wc-pakettikauppa' ), 'error' );
+      wc_add_notice(__('Please choose a pickup point.', 'wc-pakettikauppa'), 'error');
     }
   }
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -17,6 +17,9 @@
   <!-- Don't check composer dependencies and extras -->
   <exclude-pattern>/vendor/</exclude-pattern>
 
+  <!-- Extend the exclude patterns to match your .gitignore -->
+
+
   <!--
     Include WordPress Coding Standards with some exclusions. WordPress-Extra contains an extended
     ruleset for recommended best practices, see
@@ -25,21 +28,41 @@
   -->
   <rule ref="WordPress-Extra">
 
-    <!-- Exclude some rules that conflict with the use of two spaces instead of four spaces or tabs
-    for indentation -->
+    <!-- Allow spaces in indentation -->
     <exclude name="Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed" />
-    <exclude name="WordPress.WhiteSpace.PrecisionAlignment.Found" />
+
+    <!-- Don't use precision alignment -->
+    <exclude name="WordPress.WhiteSpace.PrecisionAlignment" />
+
+    <!--
+      The generic exact whitespace sniff does not work very well with inline HTML, so ignore it.
+    -->
+    <exclude name="Generic.WhiteSpace.ScopeIndent.IncorrectExact" />
+
+    <!--
+      Exclude WordPress array indent as it causes false positivies, is not very customizable
+      and we already use Generic.Arrays.ArrayIndent.
+    -->
     <exclude name="WordPress.Arrays.ArrayIndentation.ItemNotAligned" />
+
+
+    <!--
+      Causes false errors "Multi-line array item not aligned correctly" when indenting with
+      2 spaces instead of 4.
+    -->
     <exclude name="WordPress.Arrays.ArrayIndentation.MultiLineArrayItemNotAligned" />
-    <exclude name="PEAR.Functions.FunctionCallSignature" />
-    <exclude name="PSR2.ControlStructures.SwitchDeclaration.BreakIndent" />
 
-    <!-- There is no need to align equals signs -->
+    <!-- There is no need to align equals signs or array keys -->
     <exclude name="Generic.Formatting.MultipleStatementAlignment" />
+    <exclude name="WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned" />
 
-    <!-- Don't enforce the usage of excessive amounts of whitespace -->
-    <exclude name="PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket" />
-    <exclude name="PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket" />
+    <!--
+      Don't enforce the usage of excessive amounts of whitespace around opening/closing
+      brackets and around variables as array keys.
+    -->
+    <exclude name="WordPress.WhiteSpace.CastStructureSpacing.NoSpaceBeforeOpenParenthesis" />
+    <exclude name="WordPress.WhiteSpace.OperatorSpacing.NoSpaceBefore" />
+    <exclude name="WordPress.Arrays.ArrayKeySpacingRestrictions" />
 
     <!-- Yoda Condition checks reduce code readability with very little benefit -->
     <exclude name="WordPress.PHP.YodaConditions.NotYoda" />
@@ -50,37 +73,70 @@
     <!-- We need to use PHP system calls to provide grahpical wrappers for CLI commands. -->
     <exclude name="WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec" />
 
-    <!-- Don't enforce the usage of escaped output in every situation, the security risks should be
-    assessed separately. Also we can't always use nonces e.g. for APIs... -->
-    <exclude name="WordPress.CSRF.NonceVerification.NoNonceVerification" />
-    <exclude name="WordPress.XSS.EscapeOutput" />
+    <!--
+      Don't enforce the usage of escaped output in every situation, the security risks should be
+      assessed separately. Also we can't always use nonces e.g. for APIs...
+    -->
     <exclude name="WordPress.Security.EscapeOutput.UnsafePrintingFunction" />
     <exclude name="WordPress.Security.EscapeOutput.OutputNotEscaped" />
-    <exclude name="WordPress.Security.NonceVerification.NoNonceVerification" />
-
-    <!-- woo-pakettikauppa uses a lot of these, so let them stay in -->
-    <exclude name="WordPress.NamingConventions.ValidVariableName.NotSnakeCase" />
-    <exclude name="WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar" />
-
+    <exclude name="WordPress.CSRF.NonceVerification.NoNonceVerification" />
+    <exclude name="WordPress.Security.NonceVerification" />
   </rule>
+
+
+  <!-- Include Security sniffs -->
+  <rule ref="Security">
+    <!--
+      Ignore the ErrMiscIncludeMismatchNoExt sniff because it causes
+      unnecessary errors on dynamically reated require paths, e.g.
+      >>> require_once 'something-' . $somevar . '.php';
+    -->
+    <exclude name="PHPCS_Security.Misc.IncludeMismatch.ErrMiscIncludeMismatchNoExt" />
+  </rule>
+
+
+  <!-- Include PHP compatibility sniffs -->
+  <rule ref="PHPCompatibility" />
 
 
   <!--
-    Add some custom sniff rules here. See
-    https://github.com/squizlabs/PHP_CodeSniffer/wiki/Customisable-Sniff-Properties for available
-    sniffs and their properties.
+    Add some custom sniff rules in this section below. See
+    https://github.com/squizlabs/PHP_CodeSniffer/wiki/Customisable-Sniff-Properties and
+    https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties
+    for available sniffs and their properties.
   -->
-  <!-- Code blocks should be indented with two (2) spaces -->
-  <rule ref="Generic.WhiteSpace.ScopeIndent">
+
+  <!-- Set 2 spaces indentation for function call signature -->
+  <rule ref="PEAR.Functions.FunctionCallSignature">
     <properties>
       <property name="indent" value="2" />
-      <property name="exact" value="false" />
-      <property name="tabIndent" value="false" />
+      <property name="requiredSpacesAfterOpen" value="0"/>
+      <property name="requiredSpacesBeforeClose" value="0"/>
+      <property name="allowMultipleArguments" value="false"/>
     </properties>
   </rule>
 
-  <!-- The soft limit on line length is 100 characters. However, do not trigger errors if the limit
-  is exceeded. -->
+  <!--
+    Indent using two (2) spaces instead of tabs. Otherwise, use the same settings as WP Core
+    sniffs use.
+  -->
+  <rule ref="Generic.WhiteSpace.ScopeIndent">
+    <properties>
+      <property name="exact" value="false"/>
+      <property name="indent" value="2"/>
+      <property name="tabIndent" value="false"/>
+      <property name="ignoreIndentationTokens" type="array">
+        <element value="T_HEREDOC"/>
+        <element value="T_NOWDOC"/>
+        <element value="T_INLINE_HTML"/>
+      </property>
+    </properties>
+  </rule>
+
+  <!--
+    The soft limit on line length is 100 characters. However, do not trigger errors if the limit
+    is exceeded.
+  -->
   <rule ref="Generic.Files.LineLength">
     <properties>
       <property name="lineLimit" value="100"/>
@@ -88,21 +144,30 @@
     </properties>
   </rule>
 
-  <!-- Allow concatenation of multiple strings if they are located on multiple lines -->
-  <rule ref="Generic.Strings.UnnecessaryStringConcat">
+  <!-- Set 2 spaces indentation for switch terminating case statement -->
+  <rule ref="PSR2.ControlStructures.SwitchDeclaration">
     <properties>
-      <property name="allowMultiline" value="true" />
+      <property name="indent" value="2" />
     </properties>
   </rule>
 
   <!-- Enforce that multiline arrays are indented with two spaces -->
   <rule ref="Generic.Arrays.ArrayIndent">
     <properties>
+      <property name="tabIndent" value="false" />
       <property name="indent" value="2" />
     </properties>
   </rule>
 
   <!-- Explicitly forbid tabs -->
   <rule ref="Generic.WhiteSpace.DisallowTabIndent" />
+
+  <!-- Don't use spaces in arbitrary parentheses -->
+  <rule ref="Generic.WhiteSpace.ArbitraryParenthesesSpacing">
+    <properties>
+      <property name="ignoreNewlines" value="true" />
+      <property name="spacing" value="0" />
+    </properties>
+  </rule>
 
 </ruleset>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,7 +5,7 @@
  * @package Woocommerce_Pakettikauppa
  */
 
-$_tests_dir = getenv( 'WP_TESTS_DIR' );
+$_tests_dir = getenv('WP_TESTS_DIR');
 if ( ! $_tests_dir ) {
   $_tests_dir = '/tmp/wordpress-tests-lib';
 }
@@ -17,9 +17,9 @@ require_once $_tests_dir . '/includes/functions.php';
  * Manually load the plugin being tested.
  */
 function _manually_load_plugin() {
-  require dirname( dirname( __FILE__ ) ) . '/wc-pakettikauppa.php';
+  require dirname(dirname(__FILE__)) . '/wc-pakettikauppa.php';
 }
-tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
+tests_add_filter('muplugins_loaded', '_manually_load_plugin');
 
 // Start up the WP testing environment.
 require $_tests_dir . '/includes/bootstrap.php';

--- a/tests/test-sample.php
+++ b/tests/test-sample.php
@@ -15,6 +15,6 @@ class SampleTest extends WP_UnitTestCase {
    */
   public function test_sample() {
     // Replace this with some actual testing code.
-    $this->assertTrue( true );
+    $this->assertTrue(true);
   }
 }

--- a/tests/test-wc-pk-admin.php
+++ b/tests/test-wc-pk-admin.php
@@ -16,7 +16,7 @@ class Test_WC_Pakettikauppa_Admin extends WP_UnitTestCase {
    */
   public function test_admin_init() {
     $pakettikauppa_admin = new WC_Pakettikauppa_Admin();
-    $this->assertEquals( 'wc_pakettikauppa_admin', $pakettikauppa_admin->id );
+    $this->assertEquals('wc_pakettikauppa_admin', $pakettikauppa_admin->id);
     $pakettikauppa_admin->load();
 
     return $pakettikauppa_admin;
@@ -26,7 +26,7 @@ class Test_WC_Pakettikauppa_Admin extends WP_UnitTestCase {
    * @depends test_admin_init
    */
   public function test_admin_errors_empty( $pakettikauppa_admin ) {
-    $this->assertEmpty( $pakettikauppa_admin->get_errors() );
+    $this->assertEmpty($pakettikauppa_admin->get_errors());
     return $pakettikauppa_admin;
   }
 
@@ -35,8 +35,8 @@ class Test_WC_Pakettikauppa_Admin extends WP_UnitTestCase {
    */
   public function test_admin_add_error( $pakettikauppa_admin ) {
     $error = 'This is an admin testing error.';
-    $pakettikauppa_admin->add_error( $error );
-    $this->assertEquals( array( $error ), $pakettikauppa_admin->get_errors() );
+    $pakettikauppa_admin->add_error($error);
+    $this->assertEquals(array( $error ), $pakettikauppa_admin->get_errors());
     return $pakettikauppa_admin;
   }
 
@@ -45,7 +45,7 @@ class Test_WC_Pakettikauppa_Admin extends WP_UnitTestCase {
    */
   public function test_admin_clear_errors( $pakettikauppa_admin ) {
     $pakettikauppa_admin->clear_errors();
-    $this->assertEquals( array(), $pakettikauppa_admin->get_errors() );
+    $this->assertEquals(array(), $pakettikauppa_admin->get_errors());
   }
 
 }

--- a/tests/test-wc-pk.php
+++ b/tests/test-wc-pk.php
@@ -13,7 +13,7 @@ class Test_WC_Pakettikauppa extends WP_UnitTestCase {
    */
   public function test_init() {
     $pakettikauppa = new WC_Pakettikauppa();
-    $this->assertEquals( 'wc_pakettikauppa', $pakettikauppa->id );
+    $this->assertEquals('wc_pakettikauppa', $pakettikauppa->id);
     $pakettikauppa->load();
 
     return $pakettikauppa;
@@ -26,10 +26,10 @@ class Test_WC_Pakettikauppa extends WP_UnitTestCase {
    */
   public function test_wc_pakettikauppa_get_status_text( $pakettikauppa ) {
     $status = WC_Pakettikauppa_Shipment::get_status_text(13);
-    $this->assertEquals( 'Item is collected from sender - picked up', $status);
+    $this->assertEquals('Item is collected from sender - picked up', $status);
     $input  = 'abcdefg';
     $status = WC_Pakettikauppa_Shipment::get_status_text($input);
-    $this->assertEquals( 'Unknown status: ' . $input, $status );
+    $this->assertEquals('Unknown status: ' . $input, $status);
   }
 
   /**
@@ -41,7 +41,7 @@ class Test_WC_Pakettikauppa extends WP_UnitTestCase {
       1 => 'seurantakoodi',
     );
     $output = WC_Pakettikauppa_Shipment::tracking_url($inputs[1]);
-    $this->assertEquals( 'https://www.pakettikauppa.fi/seuranta/?seurantakoodi', $output);
+    $this->assertEquals('https://www.pakettikauppa.fi/seuranta/?seurantakoodi', $output);
   }
 
   /**
@@ -51,8 +51,8 @@ class Test_WC_Pakettikauppa extends WP_UnitTestCase {
     $shipment = new WC_Pakettikauppa_Shipment();
     $shipment->load();
     $pickups                 = $shipment->get_pickup_points(00100);
-    $wc_pakettikauppa_client = new Pakettikauppa\Client( array( 'test_mode' => true ) );
-    $pickup_point_data       = $wc_pakettikauppa_client->searchPickupPoints( 00100 );
-    $this->assertEquals( $pickup_point_data, $pickups);
+    $wc_pakettikauppa_client = new Pakettikauppa\Client(array( 'test_mode' => true ));
+    $pickup_point_data       = $wc_pakettikauppa_client->searchPickupPoints(00100);
+    $this->assertEquals($pickup_point_data, $pickups);
   }
 }

--- a/wc-pakettikauppa.php
+++ b/wc-pakettikauppa.php
@@ -19,14 +19,14 @@
  */
 
 // Prevent direct access to this script
-if ( ! defined( 'ABSPATH' ) ) {
+if ( ! defined('ABSPATH') ) {
   exit;
 }
 
 // @TODO: Also check for other solutions to refer to plugin_basename and plugin_dir_path in includes/ directory
-define( 'WC_PAKETTIKAUPPA_BASENAME', plugin_basename( __FILE__ ) );
-define( 'WC_PAKETTIKAUPPA_DIR', plugin_dir_path( __FILE__ ) );
-define( 'WC_PAKETTIKAUPPA_VERSION', get_file_data( __FILE__, array( 'Version' ), 'plugin' )[0] );
+define('WC_PAKETTIKAUPPA_BASENAME', plugin_basename(__FILE__));
+define('WC_PAKETTIKAUPPA_DIR', plugin_dir_path(__FILE__));
+define('WC_PAKETTIKAUPPA_VERSION', get_file_data(__FILE__, array( 'Version' ), 'plugin')[0]);
 
 /**
  * Load plugin textdomain
@@ -37,13 +37,13 @@ function wc_pakettikauppa_load_textdomain() {
   load_plugin_textdomain(
     'wc-pakettikauppa',
     false,
-    dirname( plugin_basename( __FILE__ ) ) . '/languages/'
+    dirname(plugin_basename(__FILE__)) . '/languages/'
   );
 }
 
-add_action( 'plugins_loaded', 'wc_pakettikauppa_load_textdomain' );
+add_action('plugins_loaded', 'wc_pakettikauppa_load_textdomain');
 
-require_once plugin_dir_path( __FILE__ ) . 'includes/class-wc-pakettikauppa-shipping-method.php';
+require_once plugin_dir_path(__FILE__) . 'includes/class-wc-pakettikauppa-shipping-method.php';
 
 /**
  * Load the WC_Pakettikauppa class when in frontend
@@ -51,21 +51,21 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/class-wc-pakettikauppa-ship
 function wc_pakettikauppa_load() {
 
   if ( ! is_admin() ) {
-    require_once plugin_dir_path( __FILE__ ) . 'includes/class-wc-pakettikauppa.php';
+    require_once plugin_dir_path(__FILE__) . 'includes/class-wc-pakettikauppa.php';
     $wc_pakettikauppa = new WC_Pakettikauppa();
     $wc_pakettikauppa->load();
   }
 }
 
-add_action( 'init', 'wc_pakettikauppa_load' );
+add_action('init', 'wc_pakettikauppa_load');
 
 /**
  * Load the WC_Pakettikauppa_Admin class in wp-admin
  */
 function wc_pakettikauppa_load_admin() {
-  require_once plugin_dir_path( __FILE__ ) . 'includes/class-wc-pakettikauppa-admin.php';
+  require_once plugin_dir_path(__FILE__) . 'includes/class-wc-pakettikauppa-admin.php';
   $wc_pakettikauppa_admin = new WC_Pakettikauppa_Admin();
   $wc_pakettikauppa_admin->load();
 }
 
-add_action( 'admin_init', 'wc_pakettikauppa_load_admin' );
+add_action('admin_init', 'wc_pakettikauppa_load_admin');


### PR DESCRIPTION
Motivation taken from https://github.com/Seravo/seravo-plugin/blob/master/phpcs.xml and https://seravo.com/blog/best-php-code-style-for-wordpress-developers/. Changes:
- Update phpcs.xml ruleset to better reflect our standards
- Add Security & PHP Compatibility sniffs
- Update WPCS sniffs to 2.1.0