### PR TITLE
Rewrite condition on when to show pickup point error

### DIFF
--- a/core/class-frontend.php
+++ b/core/class-frontend.php
@@ -394,7 +394,7 @@ if ( ! class_exists(__NAMESPACE__ . '\Frontend') ) {
       $key = str_replace('wc_', '', $this->core->prefix) . '_pickup_point';
       $pickup = isset($_POST[$key]) ? $_POST[$key] : false;
 
-      if ( ! $pickup || $pickup === '__NULL__' ) {
+      if ( $pickup && $pickup === '__NULL__' ) {
         $this->add_error(__('Please choose a pickup point.', 'woo-pakettikauppa'));
       }
 


### PR DESCRIPTION
Ensures that there's always a pakettikauppa_pickup_point field if the shipping method requires a pickup point