### PR TITLE
EP-16: Add shortcodes

### DIFF
--- a/core/class-core.php
+++ b/core/class-core.php
@@ -33,6 +33,7 @@ if ( ! class_exists(__NAMESPACE__ . '\Core') ) {
     public $shipping_method_instance; // Added as an afterthought to fix a bug, merge with $shippingmethod in the future.
     public $setup_wizard;
     public $product;
+    public $shortcode;
 
     public $api_config; // Used by Pakettikauppa\Client
     public $api_comment; // Used by ^
@@ -191,6 +192,7 @@ if ( ! class_exists(__NAMESPACE__ . '\Core') ) {
       // Always load classes
       $this->frontend = $this->load_frontend_class();
       $this->product = $this->load_product_class();
+      $this->shortcode = $this->load_shortcode_class();
 
       if ( $shipment_exception ) {
         $this->frontend->add_error($shipment_exception);
@@ -337,6 +339,18 @@ if ( ! class_exists(__NAMESPACE__ . '\Core') ) {
       $product->load();
 
       return $product;
+    }
+
+    /**
+     * Override this method to load a custom Product class
+     */
+    protected function load_shortcode_class() {
+      require_once 'class-shortcode.php';
+
+      $shortcode = new Shortcode($this);
+      $shortcode->load();
+
+      return $shortcode;
     }
   }
 }

--- a/core/class-shortcode.php
+++ b/core/class-shortcode.php
@@ -29,21 +29,21 @@ if ( ! class_exists(__NAMESPACE__ . '\Shortcode') ) {
      * Load hooks
      */
     public function load() {
-      add_shortcode($this->core->params_prefix . 'tracking', array($this, 'tracking_info'));
+      add_shortcode($this->core->params_prefix . 'tracking', array( $this, 'tracking_info' ));
 
       $this->shipment = $this->core->shipment;
     }
 
     /**
      * Shortcode: Show tracking code or URL
-     * 
+     *
      * @param array $attributes Shortcode attributes
-     * 
+     *
      * @property int $order Order number
      * @property string $separator Separator between elements
      * @property string $show Tracking code/URL output type. Available values: code, url, link.
      * @property boolean $new_tab Open link to new tab
-     * 
+     *
      * @return string Shortcode content
      */
     public function tracking_info( $attributes ) {

--- a/core/class-shortcode.php
+++ b/core/class-shortcode.php
@@ -1,0 +1,97 @@
+<?php
+namespace Woo_Pakettikauppa_Core;
+
+// Prevent direct access to this script
+if ( ! defined('ABSPATH') ) {
+  exit();
+}
+
+if ( ! class_exists(__NAMESPACE__ . '\Shortcode') ) {
+  class Shortcode {
+    /**
+     * @var Core
+     */
+    public $core = null;
+
+    /**
+     * Internal variables
+     */
+    private $shipment = null;
+
+    /**
+     * Constructor
+     */
+    public function __construct( Core $plugin ) {
+      $this->core = $plugin;
+    }
+
+    /**
+     * Load hooks
+     */
+    public function load() {
+      add_shortcode($this->core->params_prefix . 'tracking', array($this, 'tracking_info'));
+
+      $this->shipment = $this->core->shipment;
+    }
+
+    /**
+     * Shortcode: Show tracking code or URL
+     * 
+     * @param array $attributes Shortcode attributes
+     * 
+     * @property int $order Order number
+     * @property string $separator Separator between elements
+     * @property string $show Tracking code/URL output type. Available values: code, url, link.
+     * @property boolean $new_tab Open link to new tab
+     * 
+     * @return string Shortcode content
+     */
+    public function tracking_info( $attributes ) {
+      $default_attributes = array(
+        'order' => '',
+        'separator' => '<br/>',
+        'show' => 'code',
+        'new_tab' => 'true',
+      );
+      $atts = shortcode_atts($default_attributes, $attributes);
+
+      if ( empty($atts['order']) ) {
+        return '';
+      }
+
+      try {
+        $order = new \WC_Order(esc_attr($atts['order']));
+        $tracking_codes = $this->shipment->get_labels($order->get_id());
+      } catch ( \Exception $e ) {
+        return '';
+      }
+      if ( empty($tracking_codes) ) {
+        return '';
+      }
+
+      $output = '';
+      foreach ( $tracking_codes as $code_data ) {
+        if ( ! empty($output) ) {
+          $output .= $atts['separator'];
+        }
+        switch ( strtolower($atts['show']) ) {
+          case 'code':
+            $output .= $code_data['tracking_code'];
+            break;
+          case 'url':
+            $output .= $code_data['tracking_url'];
+            break;
+          case 'link':
+            $output .= '<a href="' . esc_url($code_data['tracking_url']) . '"';
+            if ( filter_var($atts['new_tab'], FILTER_VALIDATE_BOOLEAN) ) {
+              $output .= ' target="_blank"';
+            }
+            $output .= '>' . $code_data['tracking_code'] . '</a>';
+            break;
+        }
+      }
+
+      return $output;
+    }
+  }
+}


### PR DESCRIPTION
Added new shortcode `[pakettikauppa_tracking]` (prefix getting from `core->params_prefix`). Shortcode parameters:
- `order` - Order ID.
- `separator` - Separator between elements. Default `<br/>` (new line).
- `show` - Tracking code/URL output type. Available values: `code`, `url`, `link`. Default: `code`.
- `new_tab` - Open links to new tab. Default `true`.

Shortcode with parameters example: `[pakettikauppa_tracking order="123" separator=", " show="link" new_tab="false"]`